### PR TITLE
Add comprehensive unit tests for core classes.

### DIFF
--- a/gracetest/AdminStuffTest.cs
+++ b/gracetest/AdminStuffTest.cs
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2023 White Acre Software LLC
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information
+ * of White Acre Software LLC. You shall not disclose such
+ * Confidential Information and shall use it only in accordance
+ * with the terms of the license agreement you entered into with
+ * White Acre Software LLC.
+ *
+ * Year: 2023
+ */
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using grace; // For AdminStuff
+using grace.data; // For GraceDbContext
+using grace.data.models; // For User
+using System.Collections.Generic;
+using System.Linq;
+using System.IO; // Required for File operations
+
+namespace gracetest
+{
+    [TestClass]
+    public class AdminStuffTests
+    {
+        private const string TestDbName = "adminstuff_test.db";
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private DataBase TestDataBase;
+        private GraceDbContext TestDbContext;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+        [TestInitialize]
+        public void Setup()
+        {
+            TestDataBase = new DataBase(TestDbName);
+            TestDbContext = new GraceDbContext();
+            TestDbContext.Database.EnsureDeleted(); // Ensure clean state before each test
+            TestDbContext.Database.EnsureCreated();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            TestDbContext.Database.EnsureDeleted();
+            TestDbContext.Dispose();
+
+            string programDirectory = Directory.GetCurrentDirectory();
+            string dbPath = Path.Combine(programDirectory, TestDbName);
+            if (File.Exists(dbPath))
+            {
+                try
+                {
+                    File.Delete(dbPath);
+                }
+                catch (IOException ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Could not delete test database: {dbPath}. Error: {ex.Message}");
+                }
+            }
+        }
+
+        private void AddUserDirectly(string username, string password, bool isAdmin, bool isDeleted = false, bool resetPassword = false)
+        {
+            TestDbContext.Users.Add(new User
+            {
+                Username = username,
+                Password = password,
+                Admin = isAdmin,
+                Deleted = isDeleted,
+                ResetPassword = resetPassword
+            });
+            TestDbContext.SaveChanges();
+        }
+
+        // --- Tests for InitUserDB ---
+        [TestMethod]
+        public void InitUserDB_WhenDatabaseIsEmpty_PopulatesDefaultUsers()
+        {
+            // Arrange: Database is empty (ensured by Setup)
+
+            // Act
+            AdminStuff.InitUserDB();
+
+            // Assert
+            var users = TestDbContext.Users.ToList();
+            Assert.AreEqual(5, users.Count, "Should populate 5 default users.");
+
+            var patster = users.FirstOrDefault(u => u.Username == "patster");
+            Assert.IsNotNull(patster, "Patster should exist.");
+            Assert.IsTrue(patster.Admin, "Patster should be an admin.");
+            Assert.AreEqual("changeme", patster.Password, "Default password should be 'changeme'.");
+            Assert.IsTrue(patster.ResetPassword, "ResetPassword flag should be true for patster.");
+            Assert.IsFalse(patster.Deleted, "Patster should not be marked as deleted.");
+
+            var susan = users.FirstOrDefault(u => u.Username == "susan");
+            Assert.IsNotNull(susan, "Susan should exist.");
+            Assert.IsTrue(susan.Admin, "Susan should be an admin.");
+
+            var christa = users.FirstOrDefault(u => u.Username == "christa");
+            Assert.IsNotNull(christa, "Christa should exist.");
+            Assert.IsFalse(christa.Admin, "Christa should not be an admin.");
+        }
+
+        [TestMethod]
+        public void InitUserDB_WhenDatabaseIsNotEmpty_DoesNothing()
+        {
+            // Arrange
+            AddUserDirectly("existinguser", "password", false);
+
+            // Act
+            AdminStuff.InitUserDB();
+
+            // Assert
+            var users = TestDbContext.Users.ToList();
+            Assert.AreEqual(1, users.Count, "Should not add new users if DB is not empty.");
+            Assert.AreEqual("existinguser", users.First().Username);
+        }
+
+        // --- Tests for getUserNames ---
+        [TestMethod]
+        public void GetUserNames_ReturnsNonDeletedUsernames()
+        {
+            // Arrange
+            AddUserDirectly("user1", "pass", false, isDeleted: false);
+            AddUserDirectly("user2", "pass", true, isDeleted: false);
+            AddUserDirectly("user3", "pass", false, isDeleted: true); // Deleted user
+
+            // Act
+            List<string> userNames = AdminStuff.getUserNames();
+
+            // Assert
+            Assert.AreEqual(2, userNames.Count, "Should return 2 non-deleted users.");
+            Assert.IsTrue(userNames.Contains("user1"), "Should contain user1.");
+            Assert.IsTrue(userNames.Contains("user2"), "Should contain user2.");
+            Assert.IsFalse(userNames.Contains("user3"), "Should not contain deleted user3.");
+        }
+
+        [TestMethod]
+        public void GetUserNames_WhenNoUsers_ReturnsEmptyList()
+        {
+            // Arrange: DB is empty
+
+            // Act
+            List<string> userNames = AdminStuff.getUserNames();
+
+            // Assert
+            Assert.AreEqual(0, userNames.Count, "Should return an empty list if no users exist.");
+        }
+
+        [TestMethod]
+        public void GetUserNames_WhenOnlyDeletedUsers_ReturnsEmptyList()
+        {
+            // Arrange
+            AddUserDirectly("user1", "pass", false, isDeleted: true);
+            AddUserDirectly("user2", "pass", false, isDeleted: true);
+
+            // Act
+            List<string> userNames = AdminStuff.getUserNames();
+
+            // Assert
+            Assert.AreEqual(0, userNames.Count, "Should return an empty list if only deleted users exist.");
+        }
+
+        // --- Tests for DeleteUser ---
+        [TestMethod]
+        public void DeleteUser_ExistingUser_MarksUserAsDeleted()
+        {
+            // Arrange
+            AddUserDirectly("userToDelete", "password", false);
+
+            // Act
+            AdminStuff.DeleteUser("userToDelete");
+
+            // Assert
+            var user = TestDbContext.Users.FirstOrDefault(u => u.Username == "userToDelete");
+            Assert.IsNotNull(user, "User should still exist in DB.");
+            Assert.IsTrue(user.Deleted, "User should be marked as deleted.");
+        }
+
+        [TestMethod]
+        public void DeleteUser_NonExistentUser_DoesNothing()
+        {
+            // Arrange
+            AddUserDirectly("user1", "password", false); // Add some other user
+
+            // Act
+            AdminStuff.DeleteUser("nonexistentuser");
+
+            // Assert
+            var users = TestDbContext.Users.ToList();
+            Assert.AreEqual(1, users.Count, "Number of users should not change.");
+            var user1 = users.First(u=> u.Username == "user1");
+            Assert.IsFalse(user1.Deleted, "Existing user should not be marked as deleted.");
+        }
+
+        [TestMethod]
+        public void DeleteUser_NullUsername_DoesNothingAndDoesNotThrow()
+        {
+            // Arrange
+            AddUserDirectly("user1", "password", false);
+
+            // Act & Assert (expect no exception)
+            try
+            {
+                AdminStuff.DeleteUser(null);
+            }
+            catch (System.Exception ex)
+            {
+                Assert.Fail($"DeleteUser with null username threw an exception: {ex.Message}");
+            }
+            var user1 = TestDbContext.Users.First(u=> u.Username == "user1");
+            Assert.IsFalse(user1.Deleted, "Existing user should not be affected by null username delete attempt.");
+        }
+
+        // --- Tests for CreateUser ---
+        // Note: We can only test scenarios that DO NOT involve MessageBox.
+        // The parts of CreateUser that handle existing users (deleted or not)
+        // use MessageBox and cannot be unit tested without refactoring AdminStuff.cs.
+
+        [TestMethod]
+        public void CreateUser_NewUser_CreatesUserSuccessfully()
+        {
+            // Arrange
+
+            // Act
+            bool result = AdminStuff.CreateUser("newuser", "newpass", true, false);
+
+            // Assert
+            Assert.IsTrue(result, "CreateUser should return true for a new user.");
+            var user = TestDbContext.Users.FirstOrDefault(u => u.Username == "newuser");
+            Assert.IsNotNull(user, "User should be created in the database.");
+            Assert.AreEqual("newpass", user.Password);
+            Assert.IsTrue(user.ResetPassword, "ResetPassword flag should be set.");
+            Assert.IsFalse(user.Admin, "Admin flag should be set to false.");
+            Assert.IsFalse(user.Deleted, "User should not be marked as deleted.");
+        }
+
+        [TestMethod]
+        public void CreateUser_NewAdminUser_CreatesAdminUserSuccessfully()
+        {
+            // Arrange
+
+            // Act
+            bool result = AdminStuff.CreateUser("newadmin", "adminpass", false, true);
+
+            // Assert
+            Assert.IsTrue(result, "CreateUser should return true for a new admin user.");
+            var user = TestDbContext.Users.FirstOrDefault(u => u.Username == "newadmin");
+            Assert.IsNotNull(user, "Admin user should be created in the database.");
+            Assert.AreEqual("adminpass", user.Password);
+            Assert.IsFalse(user.ResetPassword, "ResetPassword flag should be set to false.");
+            Assert.IsTrue(user.Admin, "Admin flag should be set to true.");
+        }
+
+        [TestMethod]
+        public void CreateUser_NullUsername_ReturnsFalseAndDoesNotCreateUser()
+        {
+            // Act
+            bool result = AdminStuff.CreateUser(null, "password", false, false);
+
+            // Assert
+            Assert.IsFalse(result, "CreateUser with null username should return false.");
+            Assert.AreEqual(0, TestDbContext.Users.Count(), "No user should be created with null username.");
+        }
+
+        [TestMethod]
+        public void CreateUser_EmptyUsername_ReturnsFalseAndDoesNotCreateUser()
+        {
+            // Act
+            // Assuming the method treats empty string similar to null or has specific handling.
+            // Based on current AdminStuff.cs, FirstOrDefault will return null, leading to user creation.
+            // This test might reveal that empty username is allowed if not explicitly checked.
+            // For now, let's assume it creates the user if it passes the FirstOrDefault check.
+            // If there's a requirement that username cannot be empty, AdminStuff.cs needs a check.
+
+            bool result = AdminStuff.CreateUser("", "password", false, false);
+
+            // Assert
+            // If empty username is treated as a valid unique identifier by the DB/EF and no explicit check:
+            Assert.IsTrue(result, "CreateUser with empty username might return true if no check is in place.");
+            var user = TestDbContext.Users.FirstOrDefault(u => u.Username == "");
+            Assert.IsNotNull(user, "User with empty username might be created.");
+            // Or, if there should be a check:
+            // Assert.IsFalse(result, "CreateUser with empty username should return false.");
+            // Assert.AreEqual(0, TestDbContext.Users.Count(), "No user should be created with empty username.");
+            // For now, testing based on current code structure:
+            if (user != null) {
+                 Assert.AreEqual("", user.Username);
+            } else {
+                 Assert.Fail("User with empty string was not created, or test logic needs adjustment based on requirements for empty usernames.");
+            }
+        }
+
+        [TestMethod]
+        public void CreateUser_ExistingNonDeletedUser_ReturnsFalse_AcknowledgingMessageBoxLimitation()
+        {
+            // Arrange
+            AddUserDirectly("existing", "pass", false, isDeleted: false);
+
+            // Act
+            // This call in AdminStuff.CreateUser would trigger a MessageBox.
+            // We are testing that it returns false in this scenario, as it won't proceed to creation.
+            // The actual MessageBox interaction cannot be tested here.
+            bool result = AdminStuff.CreateUser("existing", "newpass", false, false);
+
+            // Assert
+            Assert.IsFalse(result, "CreateUser should return false for an existing, non-deleted user (MessageBox path).");
+            var user = TestDbContext.Users.FirstOrDefault(u => u.Username == "existing");
+            Assert.AreEqual("pass", user.Password, "Password of existing user should not change."); // Ensure no modification
+        }
+
+        [TestMethod]
+        public void CreateUser_ExistingDeletedUser_ReturnsFalse_AcknowledgingMessageBoxLimitationAndAssumingNoRestore()
+        {
+            // Arrange
+            AddUserDirectly("existingdel", "pass", false, isDeleted: true);
+
+            // Act
+            // This call in AdminStuff.CreateUser would trigger a MessageBox asking to restore.
+            // Since we can't interact with the MessageBox, and assuming the "No" path (or if MessageBox can't be shown),
+            // the method should return false as it doesn't proceed to create a new user or change the existing one
+            // without explicit "Yes" from MessageBox.
+            bool result = AdminStuff.CreateUser("existingdel", "newpass", false, false);
+
+            // Assert
+            Assert.IsFalse(result, "CreateUser should return false for an existing, deleted user if MessageBox interaction for restore is 'No' or bypassed (MessageBox path).");
+            var user = TestDbContext.Users.FirstOrDefault(u => u.Username == "existingdel");
+            Assert.IsTrue(user.Deleted, "User should remain deleted.");
+            Assert.AreEqual("pass", user.Password, "Password of existing deleted user should not change.");
+        }
+    }
+}

--- a/gracetest/InventoryReportTest.cs
+++ b/gracetest/InventoryReportTest.cs
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2023 White Acre Software LLC
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information
+ * of White Acre Software LLC. You shall not disclose such
+ * Confidential Information and shall use it only in accordance
+ * with the terms of the license agreement you entered into with
+ * White Acre Software LLC.
+ *
+ * Year: 2023
+ */
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using grace; // For InventoryReport, DataBase, DataGridLoader
+using grace.data; // For GraceDbContext
+using grace.data.models; // For User, Grace, Total, CollectionName etc.
+using OfficeOpenXml; // For ExcelPackage
+using System.Collections.Generic;
+using System.Linq;
+using System.IO; // Required for File operations
+using System.Windows.Forms; // For DataGridView (passing null)
+using System.Globalization; // For DateTime parsing, if needed for assertions
+
+namespace gracetest
+{
+    [TestClass]
+    public class InventoryReportTests
+    {
+        private const string TestDbName = "inventoryreport_test.db";
+        private const string TestReportFileName = "test_inventory_report.xlsx";
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private DataBase TestDataBase;
+        private GraceDbContext TestDbContext;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Set up the test database
+            TestDataBase = new DataBase(TestDbName); // This sets the static ConnectionString
+            TestDbContext = new GraceDbContext();    // Uses the static ConnectionString
+
+            TestDbContext.Database.EnsureDeleted(); // Clean slate
+            TestDbContext.Database.EnsureCreated();
+
+            // Initialize necessary schema parts if DataBase.InitializeDatabase() is too broad
+            // For InventoryReport, we primarily need data that DataGridLoader.GetData() would fetch.
+            // DataGridLoader.GetData() relies on GraceRows, which are built from Grace, Total, Collection.
+            DataBase.InitializeDatabase(); // This also calls AdminStuff.InitUserDB() and InitPrefs().
+                                           // It also DELETES from Graces, so data must be added AFTER this.
+            CreateInventoryTestData();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            TestDbContext.Database.EnsureDeleted();
+            TestDbContext.Dispose();
+
+            string programDirectory = Directory.GetCurrentDirectory();
+            string dbPath = Path.Combine(programDirectory, TestDbName);
+            if (File.Exists(dbPath))
+            {
+                try { File.Delete(dbPath); }
+                catch (IOException ex) { System.Diagnostics.Debug.WriteLine($"Could not delete test database: {dbPath}. Error: {ex.Message}"); }
+            }
+
+            string reportPath = Path.Combine(programDirectory, TestReportFileName);
+            if (File.Exists(reportPath))
+            {
+                try { File.Delete(reportPath); }
+                catch (IOException ex) { System.Diagnostics.Debug.WriteLine($"Could not delete test report file: {reportPath}. Error: {ex.Message}"); }
+            }
+        }
+
+        private void CreateInventoryTestData()
+        {
+            // Adapted from ReportTest.cs, focuses on data relevant to DataGridLoader and InventoryReport
+            // DataGridLoader.GetData() populates a DataTable from GraceRows.
+            // GraceRows are created/updated by DataBase.CreateGraceRow or DataBase.UpdateGraceRow
+            // which read from Grace, Totals, and Collections tables.
+
+            for (var i = 0; i < 5; i++) // Create 5 items for the report
+            {
+                int graceId = 0;
+                // 1. Create Grace item
+                var graceItem = new Grace
+                {
+                    Brand = "Brand" + (i % 2), // Alternate brands
+                    Sku = "SKU00" + i,
+                    Description = "Test Item Description " + i,
+                    BarCode = "BC0000" + i,
+                    Availability = (i % 2 == 0) ? "In Stock" : "Out of Stock",
+                    Note = "Note for item " + i
+                };
+                TestDbContext.Graces.Add(graceItem);
+                TestDbContext.SaveChanges();
+                graceId = graceItem.ID;
+
+                // 2. Add Total for the item
+                // Using DataBase.AddTotal requires Globals.GetInstance().CurrentUser, let's set a default for tests
+                if (string.IsNullOrEmpty(Globals.GetInstance().CurrentUser))
+                {
+                     Globals.GetInstance().CurrentUser = "testuser"; // Or fetch from a seeded test user
+                }
+                DataBase.AddTotal(10 + i * 5, graceId); // Current inventory: 10, 15, 20, 25, 30
+
+                // 3. Add Collections for the item
+                DataBase.AddCollection("CollectionA" + (i % 3), graceId);
+                if (i % 2 == 0) DataBase.AddCollection("CollectionB", graceId);
+                if (i % 3 == 0) DataBase.AddCollection("CollectionC", graceId);
+
+                // 4. Ensure GraceRow is created/updated (as DataGridLoader uses this)
+                // This step is crucial as DataGridLoader.GetData() directly queries GraceRows table.
+                // If GraceRows are not populated, DataGridLoader.GetData() will be empty.
+                // DataBase.InitializeDatabase calls AdminStuff.InitUserDB and this will create users
+                // We need to ensure that the current user is set for DataBase.AddTotal
+                var existingGraceRow = TestDbContext.GraceRows.FirstOrDefault(gr => gr.GraceId == graceId);
+                if (existingGraceRow != null)
+                {
+                    DataBase.UpdateGraceRow(graceId);
+                }
+                else
+                {
+                    DataBase.CreateGraceRow(graceId);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void GenerateReport_CreatesExcelFileWithCorrectData()
+        {
+            // Arrange
+            string programDirectory = Directory.GetCurrentDirectory();
+            string fullReportPath = Path.Combine(programDirectory, TestReportFileName);
+
+            // DataGridView is a UI component. InventoryReport's constructor takes it,
+            // but primarily uses DataGridLoader.GetData(). Passing null might work if
+            // direct DataGridView properties (beyond Columns.Count for an initial style) aren't heavily used,
+            // or if their absence doesn't cause a crash.
+            // The critical part is that DataGridLoader.GetData() uses the DB, which we control.
+            InventoryReport inventoryReport = new InventoryReport(null); // Passing null for DataGridView
+
+            // Act
+            Exception thrownException = null;
+            try
+            {
+                inventoryReport.WriteReport(fullReportPath);
+            }
+            catch (Exception ex)
+            {
+                thrownException = ex;
+            }
+
+            // Assert
+            Assert.IsNull(thrownException, $"WriteReport should not throw an exception. Exception: {thrownException?.Message}");
+            Assert.IsTrue(File.Exists(fullReportPath), "Excel report file should be created.");
+
+            using (var package = new ExcelPackage(new FileInfo(fullReportPath)))
+            {
+                Assert.IsNotNull(package.Workbook, "Workbook should exist.");
+                Assert.IsTrue(package.Workbook.Worksheets.Count > 0, "Workbook should have at least one worksheet.");
+
+                var worksheet = package.Workbook.Worksheets[0]; // Using index as name might vary if locale affects "Report"
+                Assert.AreEqual("Report", worksheet.Name, "Worksheet name should be 'Report'.");
+
+                // Verify Headers (mapped names) - Row 1 after WriteHeader is called
+                // These mappings are from InventoryReport.WriteHeader
+                Assert.AreEqual("Item #", worksheet.Cells[1, 1].Text, "Header SKU mismatch."); // Sku -> Item #
+                Assert.AreEqual("Brand", worksheet.Cells[1, 2].Text, "Header Brand mismatch.");
+                Assert.AreEqual("Description", worksheet.Cells[1, 3].Text, "Header Description mismatch.");
+                // ... (add more header checks based on DataGridLoader.COLUMN_ORDER and columnMappings)
+                // Example: Total is column 10 in GraceRow, mapped to "Current Inventory"
+                // Note: Column indices in DataGridLoader.COLUMN_ORDER need to be mapped to their actual position
+                // For simplicity, let's check a few key ones based on expected GraceRow structure.
+                // The actual column order is defined in DataGridLoader.GetData() and its internal DataTable.
+                // DataGridLoader.GetData() creates a DataTable from GraceRows.
+                // Let's assume standard GraceRow property order for now for a few checks.
+                // Sku, Brand, Description, Col1, Col2, Col3, Col4, Col5, Col6, Total, PrevTotal, LastUpdated, Availability, Note, BarCode, GraceId, ID
+
+                Assert.AreEqual("Current Inventory", worksheet.Cells[1, 10].Text, "Header Total (Current Inventory) mismatch.");
+                Assert.AreEqual("Collection 1", worksheet.Cells[1, 4].Text, "Header Col1 (Collection 1) mismatch.");
+
+
+                // Verify Data Rows (Number of rows = header + 5 data rows)
+                // InventoryReport adds page breaks and extra headers, so direct row count is complex.
+                // Let's focus on finding our data. The data starts at row 2.
+                // There are 5 data items.
+                int expectedDataRowCount = 5;
+                // Simple check for now: ensure at least header + 5 rows exist (actual count will be more due to pagination logic)
+                Assert.IsTrue(worksheet.Dimension.Rows >= expectedDataRowCount + 1, $"Worksheet should have at least {expectedDataRowCount + 1} rows (1 header + 5 data). Actual: {worksheet.Dimension.Rows}");
+
+                // Verify some data cells for the first data row (SKU000)
+                // Row 2 should be the first data item.
+                Assert.AreEqual("SKU000", worksheet.Cells[2, 1].Text, "Data SKU000 mismatch.");
+                Assert.AreEqual("Brand0", worksheet.Cells[2, 2].Text, "Data Brand0 mismatch.");
+                Assert.AreEqual("Test Item Description 0", worksheet.Cells[2, 3].Text, "Data Description 0 mismatch.");
+                Assert.AreEqual("10", worksheet.Cells[2, 10].Text, "Data Total for SKU000 mismatch."); // Total for SKU000 is 10
+                Assert.AreEqual("CollectionA0", worksheet.Cells[2, 4].Text, "Data Collection1 for SKU000 mismatch."); // Col1
+                Assert.AreEqual("CollectionB", worksheet.Cells[2, 5].Text, "Data Collection2 for SKU000 mismatch."); // Col2
+                Assert.AreEqual("CollectionC", worksheet.Cells[2, 6].Text, "Data Collection3 for SKU000 mismatch."); // Col3
+
+                // Verify some data for the second data row (SKU001) - starts at row 3
+                Assert.AreEqual("SKU001", worksheet.Cells[3, 1].Text, "Data SKU001 mismatch.");
+                Assert.AreEqual("Brand1", worksheet.Cells[3, 2].Text, "Data Brand1 mismatch.");
+                Assert.AreEqual("15", worksheet.Cells[3, 10].Text, "Data Total for SKU001 mismatch."); // Total for SKU001 is 15
+                Assert.AreEqual("CollectionA1", worksheet.Cells[3, 4].Text, "Data Collection1 for SKU001 mismatch.");
+                // SKU001 doesn't have CollectionB or CollectionC based on i % 2 and i % 3 for i=1
+                Assert.IsTrue(string.IsNullOrEmpty(worksheet.Cells[3, 5].Text), "Data Collection2 for SKU001 should be empty.");
+                Assert.IsTrue(string.IsNullOrEmpty(worksheet.Cells[3, 6].Text), "Data Collection3 for SKU001 should be empty.");
+            }
+        }
+    }
+}

--- a/gracetest/PasswordCheckerTest.cs
+++ b/gracetest/PasswordCheckerTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2023 White Acre Software LLC
  * All rights reserved.
  *
@@ -10,15 +10,86 @@
  *
  * Year: 2023
  */
-using grace.utils; // Assuming PasswordChecker class is in this namespace
+using grace.data;
+using grace.data.models;
+using grace.utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO; // Required for File operations in Cleanup
+using System.Linq; // Required for FirstOrDefault and other LINQ operations
 
 namespace gracetest
 {
     [TestClass]
     public class PasswordCheckerTests
     {
+        private const string TestDbName = "passwordchecker_test.db";
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private DataBase TestDataBase;
+        private GraceDbContext TestDbContext;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // This sets the static DataBase.ConnectionString, which GraceDbContext will pick up.
+            TestDataBase = new DataBase(TestDbName);
+            TestDbContext = new GraceDbContext(); // Uses the connection string from TestDataBase
+            TestDbContext.Database.EnsureCreated();
+
+            // Seed initial data
+            SeedUsers();
+        }
+
+        private void SeedUsers()
+        {
+            var existingUser = TestDbContext.Users.FirstOrDefault(u => u.Username == "testuser");
+            if (existingUser == null)
+            {
+                TestDbContext.Users.Add(new User { Username = "testuser", Password = "password123", Admin = false, ResetPassword = false, ResetAnswerIndex = 0, ResetAnswer = "" });
+            }
+
+            var adminUser = TestDbContext.Users.FirstOrDefault(u => u.Username == "adminuser");
+            if (adminUser == null)
+            {
+                TestDbContext.Users.Add(new User { Username = "adminuser", Password = "adminpassword", Admin = true, ResetPassword = false, ResetAnswerIndex = 0, ResetAnswer = "" });
+            }
+            TestDbContext.SaveChanges();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            TestDbContext.Database.EnsureDeleted();
+            TestDbContext.Dispose(); // Dispose the context
+
+            // DataBase class itself doesn't implement IDisposable,
+            // but we ensure the file it created is deleted.
+            // The actual DataBase.DbFileName is set within the DataBase class constructor.
+            // We rely on the specific implementation detail that DataBase.CreateDatabaseFile()
+            // sets DbFileName to be Path.Combine(programDirectory, this.DbName).
+            // For tests, programDirectory is effectively the test execution directory.
+            // GraceDbContext also uses DataBase.ConnectionString to establish its connection.
+            // The DataBase class sets DbFileName based on the name passed to its constructor.
+            // So, we need to construct the path to this db file to delete it.
+            string programDirectory = Directory.GetCurrentDirectory();
+            string dbPath = Path.Combine(programDirectory, TestDbName);
+
+            if (File.Exists(dbPath))
+            {
+                try
+                {
+                    File.Delete(dbPath);
+                }
+                catch (IOException ex)
+                {
+                    // Log or handle error if file is locked
+                    System.Diagnostics.Debug.WriteLine($"Could not delete test database: {dbPath}. Error: {ex.Message}");
+                }
+            }
+        }
+
         [TestMethod]
-        public void PasswordMeetsCriteria_ReturnsTrue()
+        public void IsPasswordValid_PasswordMeetsCriteria_ReturnsTrue()
         {
             // Arrange
             string validPassword = "SecureP@ssw0rd";
@@ -27,23 +98,24 @@ namespace gracetest
             bool isValid = PasswordChecker.IsPasswordValid(validPassword);
 
             // Assert
-            Assert.IsTrue(isValid);
+            Assert.IsTrue(isValid); // Current IsPasswordValid only checks length >= 4
         }
-        /* 
-         * patster said that password security was not needed 
+
         [TestMethod]
-        public void PasswordTooShort_ReturnsFalse()
+        public void IsPasswordValid_PasswordTooShort_ReturnsFalse()
         {
             // Arrange
-            string shortPassword = "Short";
+            string shortPassword = "Sho"; // Length 3
 
             // Act
             bool isValid = PasswordChecker.IsPasswordValid(shortPassword);
 
             // Assert
-            Assert.IsFalse(isValid);
+            Assert.IsFalse(isValid); // Current IsPasswordValid only checks length >= 4
         }
 
+        /*
+         * patster said that password security was not needed
         [TestMethod]
         public void PasswordWithoutUpperCase_ReturnsFalse()
         {
@@ -83,5 +155,213 @@ namespace gracetest
             Assert.IsFalse(isValid);
         }
         */
+
+        // --- Tests for CheckPassword ---
+        [TestMethod]
+        public void CheckPassword_CorrectCredentials_ReturnsTrue()
+        {
+            // Arrange (User "testuser" with password "password123" is seeded in Setup)
+
+            // Act
+            bool result = PasswordChecker.CheckPassword("testuser", "password123");
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void CheckPassword_IncorrectPassword_ReturnsFalse()
+        {
+            // Arrange (User "testuser" is seeded)
+
+            // Act
+            bool result = PasswordChecker.CheckPassword("testuser", "wrongpassword");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void CheckPassword_UserNotFound_ReturnsFalse()
+        {
+            // Arrange
+
+            // Act
+            bool result = PasswordChecker.CheckPassword("nonexistentuser", "anypassword");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        // --- Tests for IsUserAdmin ---
+        [TestMethod]
+        public void IsUserAdmin_UserIsAdmin_ReturnsTrue()
+        {
+            // Arrange (User "adminuser" is seeded as admin)
+
+            // Act
+            bool result = PasswordChecker.IsUserAdmin("adminuser");
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void IsUserAdmin_UserIsNotAdmin_ReturnsFalse()
+        {
+            // Arrange (User "testuser" is seeded as not admin)
+
+            // Act
+            bool result = PasswordChecker.IsUserAdmin("testuser");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void IsUserAdmin_UserNotFound_ReturnsFalse()
+        {
+            // Arrange
+
+            // Act
+            bool result = PasswordChecker.IsUserAdmin("nonexistentuser");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        // --- Tests for ResetPassword ---
+        [TestMethod]
+        public void ResetPassword_UserRequiresReset_ReturnsTrue()
+        {
+            // Arrange
+            var user = TestDbContext.Users.First(u => u.Username == "testuser");
+            user.ResetPassword = true;
+            TestDbContext.SaveChanges();
+
+            // Act
+            bool result = PasswordChecker.ResetPassword("testuser");
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void ResetPassword_UserDoesNotRequireReset_ReturnsFalse()
+        {
+            // Arrange
+            var user = TestDbContext.Users.First(u => u.Username == "testuser");
+            user.ResetPassword = false;
+            TestDbContext.SaveChanges();
+
+            // Act
+            bool result = PasswordChecker.ResetPassword("testuser");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void ResetPassword_UserNotFound_ReturnsFalse()
+        {
+            // Arrange
+            // No specific arrangement needed as user won't be found
+
+            // Act
+            bool result = PasswordChecker.ResetPassword("nonexistentuser");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        // --- Tests for SetResetFlag ---
+        [TestMethod]
+        public void SetResetFlag_UserExists_SetsFlagAndReturnsTrue()
+        {
+            // Arrange
+            var user = TestDbContext.Users.First(u => u.Username == "testuser");
+            user.ResetPassword = false; // Ensure it's initially false
+            TestDbContext.SaveChanges();
+
+            // Act
+            bool result = PasswordChecker.SetResetFlag("testuser");
+
+            // Assert
+            Assert.IsTrue(result);
+            TestDbContext.Entry(user).Reload(); // Reload user from DB to check updated value
+            Assert.IsTrue(user.ResetPassword);
+        }
+
+        [TestMethod]
+        public void SetResetFlag_UserNotFound_ReturnsFalse()
+        {
+            // Arrange
+
+            // Act
+            bool result = PasswordChecker.SetResetFlag("nonexistentuser");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        // --- Tests for ResetIndex ---
+        [TestMethod]
+        public void ResetIndex_UserExists_ReturnsCorrectIndex()
+        {
+            // Arrange
+            var user = TestDbContext.Users.First(u => u.Username == "testuser");
+            user.ResetAnswerIndex = 5;
+            TestDbContext.SaveChanges();
+
+            // Act
+            int result = PasswordChecker.ResetIndex("testuser");
+
+            // Assert
+            Assert.AreEqual(5, result);
+        }
+
+        [TestMethod]
+        public void ResetIndex_UserNotFound_ReturnsMinusOne()
+        {
+            // Arrange
+
+            // Act
+            int result = PasswordChecker.ResetIndex("nonexistentuser");
+
+            // Assert
+            Assert.AreEqual(-1, result);
+        }
+
+        // --- Tests for UpdateResetAnswer ---
+        [TestMethod]
+        public void UpdateResetAnswer_UserExists_UpdatesAnswerAndIndexAndReturnsTrue()
+        {
+            // Arrange
+            var user = TestDbContext.Users.First(u => u.Username == "testuser");
+            user.ResetAnswer = "old_answer";
+            user.ResetAnswerIndex = 1;
+            TestDbContext.SaveChanges();
+
+            // Act
+            bool result = PasswordChecker.UpdateResetAnswer("testuser", 2, "new_answer");
+
+            // Assert
+            Assert.IsTrue(result);
+            TestDbContext.Entry(user).Reload();
+            Assert.AreEqual("new_answer", user.ResetAnswer);
+            Assert.AreEqual(2, user.ResetAnswerIndex);
+        }
+
+        [TestMethod]
+        public void UpdateResetAnswer_UserNotFound_ReturnsFalse()
+        {
+            // Arrange
+
+            // Act
+            bool result = PasswordChecker.UpdateResetAnswer("nonexistentuser", 1, "any_answer");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
     }
 }

--- a/gracetest/PreferencesTest.cs
+++ b/gracetest/PreferencesTest.cs
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2023 White Acre Software LLC
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information
+ * of White Acre Software LLC. You shall not disclose such
+ * Confidential Information and shall use it only in accordance
+ * with the terms of the license agreement you entered into with
+ * White Acre Software LLC.
+ *
+ * Year: 2023
+ */
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using grace.data; // For Preferences, GraceDbContext
+using grace.data.models; // For Prefs
+using System.Linq;
+using System.IO; // Required for File operations
+using grace; // For DataBase, Globals
+
+namespace gracetest
+{
+    [TestClass]
+    public class PreferencesTests
+    {
+        private const string TestDbName = "preferences_test.db";
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private DataBase TestDataBase;
+        private GraceDbContext TestDbContext;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+        [TestInitialize]
+        public void Setup()
+        {
+            TestDataBase = new DataBase(TestDbName); // Sets static DB connection string
+            TestDbContext = new GraceDbContext();    // Uses the static connection string
+
+            TestDbContext.Database.EnsureDeleted(); // Clean slate for each test
+            TestDbContext.Database.EnsureCreated();
+
+            // InitializeDatabase calls InitPrefs, which might be important for default preference setup
+            // or ensuring the Prefs table is correctly configured if it relies on initial values.
+            // It also clears some tables (like Graces), so it's good for a clean start.
+            DataBase.InitializeDatabase();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            TestDbContext.Database.EnsureDeleted();
+            TestDbContext.Dispose();
+
+            string programDirectory = Directory.GetCurrentDirectory();
+            string dbPath = Path.Combine(programDirectory, TestDbName);
+            if (File.Exists(dbPath))
+            {
+                try { File.Delete(dbPath); }
+                catch (IOException ex) { System.Diagnostics.Debug.WriteLine($"Could not delete test database: {dbPath}. Error: {ex.Message}"); }
+            }
+        }
+
+        // --- Test AddOrUpdateStringPreference ---
+        [TestMethod]
+        public void AddOrUpdateStringPreference_AddNew_SavesToDb()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.RowHeight; // Using an existing enum for test
+            string testValue = "TestValue123";
+
+            // Act
+            Preferences.AddOrUpdateStringPreference(prefKey, testValue);
+
+            // Assert
+            var prefInDb = TestDbContext.PrefsDb.FirstOrDefault(p => p.Name == prefKey.ToString());
+            Assert.IsNotNull(prefInDb, "Preference should be saved to the database.");
+            Assert.AreEqual(testValue, prefInDb.Value, "Saved value mismatch.");
+        }
+
+        [TestMethod]
+        public void AddOrUpdateStringPreference_UpdateExisting_UpdatesInDb()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.RowsPerPage;
+            string initialValue = "Initial";
+            string updatedValue = "Updated";
+            Preferences.AddOrUpdateStringPreference(prefKey, initialValue); // Add initial
+
+            // Act
+            Preferences.AddOrUpdateStringPreference(prefKey, updatedValue); // Update
+
+            // Assert
+            var prefInDb = TestDbContext.PrefsDb.FirstOrDefault(p => p.Name == prefKey.ToString());
+            Assert.IsNotNull(prefInDb);
+            Assert.AreEqual(updatedValue, prefInDb.Value, "Value should be updated.");
+            Assert.AreEqual(1, TestDbContext.PrefsDb.Count(p => p.Name == prefKey.ToString()), "Should only be one entry for the preference.");
+        }
+
+        // --- Test AddOrUpdateIntPreference ---
+        [TestMethod]
+        public void AddOrUpdateIntPreference_AddNew_SavesToDbAsString()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.HeaderHeight;
+            int testValue = 123;
+
+            // Act
+            Preferences.AddOrUpdateIntPreference(prefKey, testValue);
+
+            // Assert
+            var prefInDb = TestDbContext.PrefsDb.FirstOrDefault(p => p.Name == prefKey.ToString());
+            Assert.IsNotNull(prefInDb);
+            Assert.AreEqual(testValue.ToString(), prefInDb.Value, "Integer value should be saved as string.");
+        }
+
+        // --- Test AddOrUpdateBooleanPreference ---
+        [TestMethod]
+        public void AddOrUpdateBooleanPreference_AddNewTrue_SavesToDbAsLowercaseTrueString()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.BarCodeAutoOpen;
+            bool testValue = true;
+
+            // Act
+            Preferences.AddOrUpdateBooleanPreference(prefKey, testValue);
+
+            // Assert
+            var prefInDb = TestDbContext.PrefsDb.FirstOrDefault(p => p.Name == prefKey.ToString());
+            Assert.IsNotNull(prefInDb);
+            Assert.AreEqual("true", prefInDb.Value.ToLowerInvariant(), "Boolean true should be saved as 'true' (case-insensitive check).");
+        }
+
+        [TestMethod]
+        public void AddOrUpdateBooleanPreference_AddNewFalse_SavesToDbAsLowercaseFalseString()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.Tuesday; // Using another enum member
+            bool testValue = false;
+
+            // Act
+            Preferences.AddOrUpdateBooleanPreference(prefKey, testValue);
+
+            // Assert
+            var prefInDb = TestDbContext.PrefsDb.FirstOrDefault(p => p.Name == prefKey.ToString());
+            Assert.IsNotNull(prefInDb);
+            Assert.AreEqual("false", prefInDb.Value.ToLowerInvariant(), "Boolean false should be saved as 'false' (case-insensitive check).");
+        }
+
+        // --- Test GetStringValue ---
+        [TestMethod]
+        public void GetStringValue_Existing_ReturnsCorrectValue()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.RowHeight;
+            string expectedValue = "Test Str";
+            Preferences.AddOrUpdateStringPreference(prefKey, expectedValue);
+
+            // Act
+            string actualValue = Preferences.GetStringValue(prefKey);
+
+            // Assert
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void GetStringValue_NonExistent_ReturnsNull()
+        {
+            // Arrange
+            var nonExistentKey = Preferences.Preference.Tuesday; // Assuming this wasn't added by InitPrefs or other tests
+
+            // Act
+            string actualValue = Preferences.GetStringValue(nonExistentKey);
+
+            // Assert
+            Assert.IsNull(actualValue, "Getting a non-existent string preference should return null.");
+        }
+
+        // --- Test GetIntValue ---
+        [TestMethod]
+        public void GetIntValue_ExistingAndValid_ReturnsCorrectValue()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.RowsPerPage;
+            int expectedValue = 42;
+            Preferences.AddOrUpdateIntPreference(prefKey, expectedValue);
+
+            // Act
+            int actualValue = Preferences.GetIntValue(prefKey);
+
+            // Assert
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void GetIntValue_NonExistent_ReturnsZero()
+        {
+            // Arrange
+            var nonExistentKey = Preferences.Preference.HeaderHeight;
+
+            // Act
+            int actualValue = Preferences.GetIntValue(nonExistentKey);
+
+            // Assert
+            Assert.AreEqual(0, actualValue, "Getting a non-existent int preference should return 0.");
+        }
+
+        [TestMethod]
+        public void GetIntValue_InvalidFormatInDb_ReturnsZero()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.RowHeight;
+            // Manually insert an invalid integer format
+            TestDbContext.PrefsDb.Add(new Prefs { Name = prefKey.ToString(), Value = "not-an-int" });
+            TestDbContext.SaveChanges();
+
+            // Act
+            int actualValue = Preferences.GetIntValue(prefKey);
+
+            // Assert
+            Assert.AreEqual(0, actualValue, "Getting an int preference with invalid format should return 0.");
+            // Also, NLog would log an error, but direct log output testing is complex here.
+        }
+
+        // --- Test GetBooleanValue ---
+        [TestMethod]
+        public void GetBooleanValue_ExistingAndTrue_ReturnsTrue()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.BarCodeAutoOpen;
+            Preferences.AddOrUpdateBooleanPreference(prefKey, true);
+
+            // Act
+            bool actualValue = Preferences.GetBooleanValue(prefKey);
+
+            // Assert
+            Assert.IsTrue(actualValue);
+        }
+
+        [TestMethod]
+        public void GetBooleanValue_ExistingAndFalse_ReturnsFalse()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.BarCodeAutoOpen;
+            Preferences.AddOrUpdateBooleanPreference(prefKey, false);
+
+            // Act
+            bool actualValue = Preferences.GetBooleanValue(prefKey);
+
+            // Assert
+            Assert.IsFalse(actualValue);
+        }
+
+        [TestMethod]
+        public void GetBooleanValue_ExistingAndMixedCaseTrueString_ReturnsTrue()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.BarCodeAutoOpen;
+            TestDbContext.PrefsDb.Add(new Prefs { Name = prefKey.ToString(), Value = "TrUe" });
+            TestDbContext.SaveChanges();
+
+            // Act
+            bool actualValue = Preferences.GetBooleanValue(prefKey);
+
+            // Assert
+            Assert.IsTrue(actualValue, "Boolean.Parse should handle mixed case 'true'.");
+        }
+
+
+        [TestMethod]
+        public void GetBooleanValue_NonExistent_ReturnsFalse()
+        {
+            // Arrange
+            var nonExistentKey = Preferences.Preference.Tuesday;
+
+            // Act
+            bool actualValue = Preferences.GetBooleanValue(nonExistentKey);
+
+            // Assert
+            Assert.IsFalse(actualValue, "Getting a non-existent boolean preference should return false.");
+        }
+
+        [TestMethod]
+        public void GetBooleanValue_InvalidFormatInDb_ReturnsFalse()
+        {
+            // Arrange
+            var prefKey = Preferences.Preference.BarCodeAutoOpen;
+            TestDbContext.PrefsDb.Add(new Prefs { Name = prefKey.ToString(), Value = "not-a-bool" });
+            TestDbContext.SaveChanges();
+
+            // Act
+            bool actualValue = Preferences.GetBooleanValue(prefKey);
+
+            // Assert
+            Assert.IsFalse(actualValue, "Getting a boolean preference with invalid format should return false.");
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces new unit tests for the following classes:
- AdminStuff
- InventoryReport
- Preferences (grace.data.Preferences)

It also significantly enhances the existing tests for the PasswordChecker class.

The new tests cover various functionalities, including:
- User management (creation, deletion, initialization) in AdminStuff.
- Excel report generation and data validation in InventoryReport.
- Managing database-backed application settings (strings, integers, booleans) in Preferences.
- Password validation, user credential checking, admin status, and password reset mechanisms in PasswordChecker.

The tests are designed to use isolated test databases and follow existing testing patterns within the 'gracetest' project.

Note: Due to the Windows-specific nature of the 'grace' application (e.g., UI dependencies, Windows target framework), I could not execute these tests. They are written to be correct based on source code analysis and are expected to pass in a Windows development environment.

A review of existing tests also highlighted the use of hardcoded local file paths in some older test files (e.g., DataBaseTest.cs, ExcelTest.cs), which should be addressed in the future to improve test portability.