### PR TITLE
feat: Apply wedding and catering theme to application UI

### DIFF
--- a/grace/AboutBox.Designer.cs
+++ b/grace/AboutBox.Designer.cs
@@ -37,7 +37,8 @@
             // programLabel
             // 
             programLabel.AutoSize = true;
-            programLabel.Font = new Font("Segoe UI", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 0);
+            programLabel.Font = new System.Drawing.Font("Georgia", 11F, FontStyle.Bold);
+            programLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             programLabel.Location = new Point(69, 31);
             programLabel.Name = "programLabel";
             programLabel.Size = new Size(231, 25);
@@ -47,7 +48,8 @@
             // authorLabel
             // 
             authorLabel.AutoSize = true;
-            authorLabel.Font = new Font("Segoe UI", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 0);
+            authorLabel.Font = new System.Drawing.Font("Georgia", 11F, FontStyle.Bold);
+            authorLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             authorLabel.Location = new Point(69, 80);
             authorLabel.Name = "authorLabel";
             authorLabel.Size = new Size(337, 25);
@@ -57,7 +59,8 @@
             // buildLabel
             // 
             buildLabel.AutoSize = true;
-            buildLabel.Font = new Font("Segoe UI", 12F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            buildLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            buildLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             buildLabel.Location = new Point(238, 146);
             buildLabel.Name = "buildLabel";
             buildLabel.Size = new Size(265, 21);
@@ -66,24 +69,33 @@
             // 
             // button1
             // 
-            button1.Font = new Font("Segoe UI", 12F, FontStyle.Bold, GraphicsUnit.Point, 0);
+            button1.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            button1.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            button1.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            button1.FlatAppearance.BorderSize = 1;
+            button1.FlatStyle = FlatStyle.Flat;
+            button1.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            button1.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             button1.Location = new Point(69, 146);
             button1.Name = "button1";
             button1.Size = new Size(86, 42);
             button1.TabIndex = 3;
             button1.Text = "Close";
-            button1.UseVisualStyleBackColor = true;
+            button1.UseVisualStyleBackColor = false;
             button1.Click += Button1_Click;
             // 
             // AboutBox
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             ClientSize = new Size(520, 200);
             Controls.Add(button1);
             Controls.Add(buildLabel);
             Controls.Add(authorLabel);
             Controls.Add(programLabel);
+            Font = new System.Drawing.Font("Segoe UI", 10F);
+            ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             Name = "AboutBox";
             ShowIcon = false;
             ShowInTaskbar = false;

--- a/grace/Vivian.Designer.cs
+++ b/grace/Vivian.Designer.cs
@@ -33,9 +33,27 @@ namespace grace
         {
             components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Vivian));
+            DataGridViewCellStyle dataGridViewCellStyle1 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle2 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle3 = new DataGridViewCellStyle();
             DataGridViewCellStyle dataGridViewCellStyle4 = new DataGridViewCellStyle();
             DataGridViewCellStyle dataGridViewCellStyle5 = new DataGridViewCellStyle();
             DataGridViewCellStyle dataGridViewCellStyle6 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle7 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle8 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle9 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle10 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle11 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle12 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle13 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle14 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle15 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle16 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle17 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle18 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle19 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle20 = new DataGridViewCellStyle();
+            DataGridViewCellStyle dataGridViewCellStyle21 = new DataGridViewCellStyle();
             openFileDialog = new OpenFileDialog();
             menuStrip1 = new MenuStrip();
             editToolStripMenuItem = new ToolStripMenuItem();
@@ -134,7 +152,9 @@ namespace grace
             // 
             // menuStrip1
             // 
-            menuStrip1.Font = new Font("Segoe UI", 12F, FontStyle.Bold);
+            menuStrip1.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            menuStrip1.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            menuStrip1.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             menuStrip1.ImageScalingSize = new Size(32, 32);
             menuStrip1.Items.AddRange(new ToolStripItem[] { editToolStripMenuItem, viewToolStripMenuItem });
             menuStrip1.Location = new Point(0, 0);
@@ -147,13 +167,15 @@ namespace grace
             // editToolStripMenuItem
             // 
             editToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { settingsToolStripMenuItem, importInventoryToolStripMenuItem, saveInventoryReportToolStripMenuItem, saveReportToolStripMenuItem, aboutToolStripMenuItem, exitToolStripMenuItem });
-            editToolStripMenuItem.Font = new Font("Segoe UI", 10.875F, FontStyle.Bold);
+            editToolStripMenuItem.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            editToolStripMenuItem.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             editToolStripMenuItem.Name = "editToolStripMenuItem";
             editToolStripMenuItem.Size = new Size(45, 25);
             editToolStripMenuItem.Text = "File";
             // 
             // settingsToolStripMenuItem
             // 
+            settingsToolStripMenuItem.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
             settingsToolStripMenuItem.Size = new Size(235, 24);
             settingsToolStripMenuItem.Text = "Settings";
@@ -161,6 +183,7 @@ namespace grace
             // 
             // importInventoryToolStripMenuItem
             // 
+            importInventoryToolStripMenuItem.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             importInventoryToolStripMenuItem.Name = "importInventoryToolStripMenuItem";
             importInventoryToolStripMenuItem.Size = new Size(235, 24);
             importInventoryToolStripMenuItem.Text = "Import Inventory";
@@ -168,12 +191,14 @@ namespace grace
             // 
             // saveInventoryReportToolStripMenuItem
             // 
+            saveInventoryReportToolStripMenuItem.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             saveInventoryReportToolStripMenuItem.Name = "saveInventoryReportToolStripMenuItem";
             saveInventoryReportToolStripMenuItem.Size = new Size(235, 24);
             saveInventoryReportToolStripMenuItem.Text = "Save Inventory Report";
             // 
             // saveReportToolStripMenuItem
             // 
+            saveReportToolStripMenuItem.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             saveReportToolStripMenuItem.Name = "saveReportToolStripMenuItem";
             saveReportToolStripMenuItem.Size = new Size(235, 24);
             saveReportToolStripMenuItem.Text = "Save Collection Report";
@@ -181,6 +206,7 @@ namespace grace
             // 
             // aboutToolStripMenuItem
             // 
+            aboutToolStripMenuItem.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
             aboutToolStripMenuItem.Size = new Size(235, 24);
             aboutToolStripMenuItem.Text = "About";
@@ -188,6 +214,7 @@ namespace grace
             // 
             // exitToolStripMenuItem
             // 
+            exitToolStripMenuItem.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             exitToolStripMenuItem.Name = "exitToolStripMenuItem";
             exitToolStripMenuItem.Size = new Size(235, 24);
             exitToolStripMenuItem.Text = "Exit";
@@ -196,12 +223,14 @@ namespace grace
             // viewToolStripMenuItem
             // 
             viewToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { setInventoryFontSizeToolStripMenuItem });
+            viewToolStripMenuItem.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             viewToolStripMenuItem.Name = "viewToolStripMenuItem";
             viewToolStripMenuItem.Size = new Size(60, 25);
             viewToolStripMenuItem.Text = "View";
             // 
             // setInventoryFontSizeToolStripMenuItem
             // 
+            setInventoryFontSizeToolStripMenuItem.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             setInventoryFontSizeToolStripMenuItem.Name = "setInventoryFontSizeToolStripMenuItem";
             setInventoryFontSizeToolStripMenuItem.Size = new Size(256, 26);
             setInventoryFontSizeToolStripMenuItem.Text = "Set Inventory Font Size";
@@ -232,7 +261,7 @@ namespace grace
             tabControl.Controls.Add(collectionPage);
             tabControl.Controls.Add(adminPage);
             tabControl.DrawMode = TabDrawMode.OwnerDrawFixed;
-            tabControl.Font = new Font("Verdana", 11.25F, FontStyle.Bold, GraphicsUnit.Point, 0);
+            tabControl.Font = new System.Drawing.Font("Georgia", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             tabControl.HotTrack = true;
             tabControl.ItemSize = new Size(200, 40);
             tabControl.Location = new Point(0, 31);
@@ -249,7 +278,7 @@ namespace grace
             // 
             // loginPage
             // 
-            loginPage.BackColor = Color.Lavender;
+            loginPage.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             loginPage.BorderStyle = BorderStyle.Fixed3D;
             loginPage.Controls.Add(loggedInLabel);
             loginPage.Controls.Add(logoutButton);
@@ -272,6 +301,8 @@ namespace grace
             // loggedInLabel
             // 
             loggedInLabel.AutoSize = true;
+            loggedInLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            loggedInLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             loggedInLabel.Location = new Point(266, 452);
             loggedInLabel.Name = "loggedInLabel";
             loggedInLabel.Size = new Size(57, 18);
@@ -281,15 +312,25 @@ namespace grace
             // logoutButton
             // 
             logoutButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            logoutButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            logoutButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            logoutButton.FlatAppearance.BorderSize = 1;
+            logoutButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            logoutButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            logoutButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             logoutButton.Location = new Point(247, 490);
             logoutButton.Name = "logoutButton";
             logoutButton.Size = new Size(116, 33);
             logoutButton.TabIndex = 1;
             logoutButton.Text = "Logout";
-            logoutButton.UseVisualStyleBackColor = true;
+            logoutButton.UseVisualStyleBackColor = false;
             // 
             // passwordTextBox
             // 
+            passwordTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            passwordTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            passwordTextBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            passwordTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             passwordTextBox.Location = new Point(448, 301);
             passwordTextBox.Name = "passwordTextBox";
             passwordTextBox.PasswordChar = '*';
@@ -300,16 +341,25 @@ namespace grace
             // 
             loginButton.AutoSize = true;
             loginButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            loginButton.Font = new Font("Segoe UI", 14.25F, FontStyle.Bold);
+            loginButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            loginButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            loginButton.FlatAppearance.BorderSize = 1;
+            loginButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            loginButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            loginButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             loginButton.Location = new Point(498, 371);
             loginButton.Name = "loginButton";
             loginButton.Size = new Size(73, 35);
             loginButton.TabIndex = 19;
             loginButton.Text = "Login";
-            loginButton.UseVisualStyleBackColor = true;
+            loginButton.UseVisualStyleBackColor = false;
             // 
             // comboBoxUsers
             // 
+            comboBoxUsers.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            comboBoxUsers.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            comboBoxUsers.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            comboBoxUsers.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             comboBoxUsers.FormattingEnabled = true;
             comboBoxUsers.Location = new Point(448, 242);
             comboBoxUsers.Name = "comboBoxUsers";
@@ -319,6 +369,8 @@ namespace grace
             // passwordLabel
             // 
             passwordLabel.AutoSize = true;
+            passwordLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            passwordLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             passwordLabel.Location = new Point(254, 309);
             passwordLabel.Name = "passwordLabel";
             passwordLabel.Size = new Size(88, 18);
@@ -328,7 +380,9 @@ namespace grace
             // pickUserLabel
             // 
             pickUserLabel.AutoSize = true;
-            pickUserLabel.BackColor = Color.Transparent;
+            pickUserLabel.BackColor = System.Drawing.Color.Transparent;
+            pickUserLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            pickUserLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             pickUserLabel.Location = new Point(254, 245);
             pickUserLabel.Name = "pickUserLabel";
             pickUserLabel.Size = new Size(84, 18);
@@ -339,19 +393,24 @@ namespace grace
             // 
             changePasswordButton.AutoSize = true;
             changePasswordButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            changePasswordButton.Font = new Font("Segoe UI", 14.25F, FontStyle.Bold);
+            changePasswordButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            changePasswordButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            changePasswordButton.FlatAppearance.BorderSize = 1;
+            changePasswordButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            changePasswordButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            changePasswordButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             changePasswordButton.Location = new Point(254, 371);
             changePasswordButton.Name = "changePasswordButton";
             changePasswordButton.Size = new Size(179, 35);
             changePasswordButton.TabIndex = 22;
             changePasswordButton.Text = "Change Password";
-            changePasswordButton.UseVisualStyleBackColor = true;
+            changePasswordButton.UseVisualStyleBackColor = false;
             // 
             // dataPage
             // 
             dataPage.AutoScroll = true;
             dataPage.AutoScrollMargin = new Size(5, 5);
-            dataPage.BackColor = Color.Lavender;
+            dataPage.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             dataPage.BorderStyle = BorderStyle.Fixed3D;
             dataPage.Controls.Add(dataGridView);
             dataPage.Controls.Add(filterBarcodeTextBox);
@@ -367,32 +426,241 @@ namespace grace
             dataPage.TabIndex = 1;
             dataPage.Text = "Inventory";
             dataPage.ToolTipText = "Inventory for Patster";
+            // dataGridViewCellStyle1
+            //
+            dataGridViewCellStyle1.BackColor = System.Drawing.ColorTranslator.FromHtml("#F8F0E3");
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle1.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            //
+            // dataGridViewCellStyle2
+            //
+            dataGridViewCellStyle2.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle2.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle2.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle2.WrapMode = DataGridViewTriState.True;
+            dataGridViewCellStyle2.BorderStyle = DataGridViewHeaderBorderStyle.Single;
+            //
+            // dataGridViewCellStyle3
+            //
+            dataGridViewCellStyle3.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle3.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle3.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle3.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle3.WrapMode = DataGridViewTriState.True;
+            //
+            // dataGridViewCellStyle4
+            //
+            dataGridViewCellStyle4.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle4.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            dataGridViewCellStyle4.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle4.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle4.WrapMode = DataGridViewTriState.False;
+            //
+            // dataGridViewCellStyle5
+            //
+            dataGridViewCellStyle5.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle5.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle5.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle5.Padding = new Padding(0, 2, 10, 0); // Keep existing padding
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle5.WrapMode = DataGridViewTriState.False;
+            //
+            // dataGridViewCellStyle6
+            //
+            dataGridViewCellStyle6.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle6.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            dataGridViewCellStyle6.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle6.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle6.Padding = new Padding(0, 0, 10, 0); // Keep existing padding
+            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            //
+            // dataGridViewCellStyle7
+            //
+            dataGridViewCellStyle7.BackColor = System.Drawing.ColorTranslator.FromHtml("#F8F0E3");
+            dataGridViewCellStyle7.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle7.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle7.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle7.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            //
+            // dataGridViewCellStyle8
+            //
+            dataGridViewCellStyle8.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle8.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle8.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle8.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle8.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle8.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle8.WrapMode = DataGridViewTriState.True;
+            dataGridViewCellStyle8.BorderStyle = DataGridViewHeaderBorderStyle.Single;
+            //
+            // dataGridViewCellStyle9
+            //
+            dataGridViewCellStyle9.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle9.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle9.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle9.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle9.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle9.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle9.WrapMode = DataGridViewTriState.True;
+            //
+            // dataGridViewCellStyle10
+            //
+            dataGridViewCellStyle10.BackColor = System.Drawing.ColorTranslator.FromHtml("#F8F0E3");
+            dataGridViewCellStyle10.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle10.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle10.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle10.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            //
+            // dataGridViewCellStyle11
+            //
+            dataGridViewCellStyle11.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle11.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle11.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle11.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle11.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle11.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle11.WrapMode = DataGridViewTriState.True;
+            dataGridViewCellStyle11.BorderStyle = DataGridViewHeaderBorderStyle.Single; // Apply consistent border
+            //
+            // dataGridViewCellStyle12
+            //
+            dataGridViewCellStyle12.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle12.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            dataGridViewCellStyle12.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle12.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle12.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle12.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle12.WrapMode = DataGridViewTriState.False;
+            //
+            // dataGridViewCellStyle13
+            //
+            dataGridViewCellStyle13.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle13.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle13.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle13.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle13.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle13.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle13.WrapMode = DataGridViewTriState.True;
+            //
+            // dataGridViewCellStyle14
+            //
+            dataGridViewCellStyle14.BackColor = System.Drawing.ColorTranslator.FromHtml("#F8F0E3");
+            dataGridViewCellStyle14.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle14.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle14.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle14.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            //
+            // dataGridViewCellStyle15
+            //
+            dataGridViewCellStyle15.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle15.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle15.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle15.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle15.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle15.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle15.WrapMode = DataGridViewTriState.True;
+            dataGridViewCellStyle15.BorderStyle = DataGridViewHeaderBorderStyle.Single; // Apply consistent border
+            //
+            // dataGridViewCellStyle16
+            //
+            dataGridViewCellStyle16.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle16.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            dataGridViewCellStyle16.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle16.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle16.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle16.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle16.WrapMode = DataGridViewTriState.False;
+            //
+            // dataGridViewCellStyle17
+            //
+            dataGridViewCellStyle17.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle17.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle17.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle17.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle17.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle17.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle17.WrapMode = DataGridViewTriState.True;
+            //
+            // dataGridViewCellStyle18
+            //
+            dataGridViewCellStyle18.BackColor = System.Drawing.ColorTranslator.FromHtml("#F8F0E3");
+            dataGridViewCellStyle18.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle18.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle18.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle18.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            //
+            // dataGridViewCellStyle19
+            //
+            dataGridViewCellStyle19.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle19.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle19.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle19.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle19.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle19.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle19.WrapMode = DataGridViewTriState.True;
+            dataGridViewCellStyle19.BorderStyle = DataGridViewHeaderBorderStyle.Single; // Apply consistent border
+            //
+            // dataGridViewCellStyle20
+            //
+            dataGridViewCellStyle20.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle20.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            dataGridViewCellStyle20.Font = new System.Drawing.Font("Segoe UI", 10F);
+            dataGridViewCellStyle20.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle20.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle20.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle20.WrapMode = DataGridViewTriState.False;
+            //
+            // dataGridViewCellStyle21
+            //
+            dataGridViewCellStyle21.Alignment = DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle21.BackColor = System.Drawing.ColorTranslator.FromHtml("#EADDCA");
+            dataGridViewCellStyle21.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold);
+            dataGridViewCellStyle21.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle21.SelectionBackColor = System.Drawing.ColorTranslator.FromHtml("#E0C97F");
+            dataGridViewCellStyle21.SelectionForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            dataGridViewCellStyle21.WrapMode = DataGridViewTriState.True;
             // 
             // dataGridView
             // 
+            dataGridView.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
             dataGridView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             dataGridView.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells;
             dataGridView.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells;
+            dataGridView.BackgroundColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
+            dataGridView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             dataGridView.ClipboardCopyMode = DataGridViewClipboardCopyMode.Disable;
+            dataGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
             dataGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dataGridViewCellStyle4.Alignment = DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle4.BackColor = SystemColors.Window;
-            dataGridViewCellStyle4.Font = new Font("Verdana", 9F);
-            dataGridViewCellStyle4.ForeColor = SystemColors.ControlText;
-            dataGridViewCellStyle4.SelectionBackColor = SystemColors.Highlight;
-            dataGridViewCellStyle4.SelectionForeColor = SystemColors.HighlightText;
-            dataGridViewCellStyle4.WrapMode = DataGridViewTriState.False;
             dataGridView.DefaultCellStyle = dataGridViewCellStyle4;
             dataGridView.EditMode = DataGridViewEditMode.EditProgrammatically;
+            dataGridView.EnableHeadersVisualStyles = false;
+            dataGridView.GridColor = System.Drawing.ColorTranslator.FromHtml("#D3C0B1");
             dataGridView.Location = new Point(4, 61);
             dataGridView.MultiSelect = false;
             dataGridView.Name = "dataGridView";
+            dataGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
             dataGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
             dataGridView.Size = new Size(1503, 664);
             dataGridView.TabIndex = 8;
             // 
             // filterBarcodeTextBox
             // 
+            filterBarcodeTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            filterBarcodeTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            filterBarcodeTextBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            filterBarcodeTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             filterBarcodeTextBox.Location = new Point(730, 13);
             filterBarcodeTextBox.Name = "filterBarcodeTextBox";
             filterBarcodeTextBox.Size = new Size(202, 26);
@@ -401,6 +669,8 @@ namespace grace
             // scanBarcodeLabel
             // 
             scanBarcodeLabel.AutoSize = true;
+            scanBarcodeLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            scanBarcodeLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             scanBarcodeLabel.Location = new Point(600, 16);
             scanBarcodeLabel.Margin = new Padding(4, 0, 4, 0);
             scanBarcodeLabel.Name = "scanBarcodeLabel";
@@ -412,6 +682,8 @@ namespace grace
             // filterRowsLabel
             // 
             filterRowsLabel.AutoSize = true;
+            filterRowsLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            filterRowsLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             filterRowsLabel.Location = new Point(206, 13);
             filterRowsLabel.Margin = new Padding(4, 0, 4, 0);
             filterRowsLabel.Name = "filterRowsLabel";
@@ -422,26 +694,42 @@ namespace grace
             // 
             // addRowButton
             // 
+            addRowButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            addRowButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            addRowButton.FlatAppearance.BorderSize = 1;
+            addRowButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            addRowButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            addRowButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             addRowButton.Location = new Point(41, 8);
             addRowButton.Name = "addRowButton";
             addRowButton.Size = new Size(118, 35);
             addRowButton.TabIndex = 4;
             addRowButton.Text = "Add Item";
-            addRowButton.UseVisualStyleBackColor = true;
+            addRowButton.UseVisualStyleBackColor = false;
             // 
             // clearFilterButton
             // 
             clearFilterButton.AutoSize = true;
+            clearFilterButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            clearFilterButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            clearFilterButton.FlatAppearance.BorderSize = 1;
+            clearFilterButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            clearFilterButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            clearFilterButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             clearFilterButton.Location = new Point(959, 8);
             clearFilterButton.Margin = new Padding(4, 6, 4, 6);
             clearFilterButton.Name = "clearFilterButton";
             clearFilterButton.Size = new Size(147, 32);
             clearFilterButton.TabIndex = 5;
             clearFilterButton.Text = "Clear Filter";
-            clearFilterButton.UseVisualStyleBackColor = true;
+            clearFilterButton.UseVisualStyleBackColor = false;
             // 
             // filterSkuTextBox
             // 
+            filterSkuTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            filterSkuTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            filterSkuTextBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            filterSkuTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             filterSkuTextBox.Location = new Point(362, 13);
             filterSkuTextBox.Margin = new Padding(4, 3, 4, 3);
             filterSkuTextBox.Name = "filterSkuTextBox";
@@ -450,7 +738,7 @@ namespace grace
             // 
             // checkoutPage
             // 
-            checkoutPage.BackColor = Color.Lavender;
+            checkoutPage.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             checkoutPage.Controls.Add(textBoxBarcode);
             checkoutPage.Controls.Add(checkOutSearchTextBox);
             checkoutPage.Controls.Add(label6);
@@ -469,6 +757,10 @@ namespace grace
             // textBoxBarcode
             // 
             textBoxBarcode.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            textBoxBarcode.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            textBoxBarcode.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            textBoxBarcode.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            textBoxBarcode.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             textBoxBarcode.Location = new Point(1259, 144);
             textBoxBarcode.Name = "textBoxBarcode";
             textBoxBarcode.Size = new Size(246, 26);
@@ -477,6 +769,10 @@ namespace grace
             // checkOutSearchTextBox
             // 
             checkOutSearchTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            checkOutSearchTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            checkOutSearchTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            checkOutSearchTextBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            checkOutSearchTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             checkOutSearchTextBox.Location = new Point(1246, 190);
             checkOutSearchTextBox.Name = "checkOutSearchTextBox";
             checkOutSearchTextBox.Size = new Size(259, 26);
@@ -485,6 +781,8 @@ namespace grace
             // label6
             // 
             label6.AutoSize = true;
+            label6.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            label6.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label6.Location = new Point(1132, 152);
             label6.Name = "label6";
             label6.Size = new Size(118, 18);
@@ -495,10 +793,10 @@ namespace grace
             // 
             label7.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             label7.AutoSize = true;
-            label7.BackColor = Color.Transparent;
+            label7.BackColor = Color.Transparent; // Potentially keep transparent or match page bg
             label7.BorderStyle = BorderStyle.FixedSingle;
-            label7.Font = new Font("Verdana", 15.75F, FontStyle.Bold);
-            label7.ForeColor = SystemColors.Highlight;
+            label7.Font = new System.Drawing.Font("Georgia", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0))); // Heading Font
+            label7.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F"); // Charcoal Text
             label7.Location = new Point(1108, 429);
             label7.Name = "label7";
             label7.Size = new Size(397, 77);
@@ -508,6 +806,8 @@ namespace grace
             // label8
             // 
             label8.AutoSize = true;
+            label8.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            label8.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label8.Location = new Point(1131, 198);
             label8.Name = "label8";
             label8.Size = new Size(104, 18);
@@ -518,39 +818,41 @@ namespace grace
             // 
             coResetButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             coResetButton.AutoSize = true;
+            coResetButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            coResetButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            coResetButton.FlatAppearance.BorderSize = 1;
+            coResetButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            coResetButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            coResetButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             coResetButton.Location = new Point(1246, 274);
             coResetButton.Name = "coResetButton";
             coResetButton.Size = new Size(259, 46);
             coResetButton.TabIndex = 7;
             coResetButton.Text = "Show All Data";
-            coResetButton.UseVisualStyleBackColor = true;
+            coResetButton.UseVisualStyleBackColor = false;
             // 
             // checkOutDataGrid
             // 
             checkOutDataGrid.AllowUserToAddRows = false;
             checkOutDataGrid.AllowUserToDeleteRows = false;
+            checkOutDataGrid.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle7;
             checkOutDataGrid.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
             checkOutDataGrid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells;
             checkOutDataGrid.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells;
-            checkOutDataGrid.BorderStyle = BorderStyle.Fixed3D;
+            checkOutDataGrid.BackgroundColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
+            checkOutDataGrid.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            checkOutDataGrid.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle8;
             checkOutDataGrid.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dataGridViewCellStyle5.Alignment = DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle5.BackColor = Color.FromArgb(224, 224, 224);
-            dataGridViewCellStyle5.Font = new Font("Verdana", 11.25F, FontStyle.Bold);
-            dataGridViewCellStyle5.ForeColor = SystemColors.ControlText;
-            dataGridViewCellStyle5.Padding = new Padding(0, 2, 10, 0);
-            dataGridViewCellStyle5.SelectionBackColor = SystemColors.Highlight;
-            dataGridViewCellStyle5.SelectionForeColor = SystemColors.HighlightText;
-            dataGridViewCellStyle5.WrapMode = DataGridViewTriState.False;
-            checkOutDataGrid.DefaultCellStyle = dataGridViewCellStyle5;
+            checkOutDataGrid.DefaultCellStyle = dataGridViewCellStyle5; // Will be updated
+            checkOutDataGrid.EnableHeadersVisualStyles = false;
+            checkOutDataGrid.GridColor = System.Drawing.ColorTranslator.FromHtml("#D3C0B1");
             checkOutDataGrid.Location = new Point(5, 3);
             checkOutDataGrid.MultiSelect = false;
             checkOutDataGrid.Name = "checkOutDataGrid";
             checkOutDataGrid.ReadOnly = true;
+            checkOutDataGrid.RowHeadersDefaultCellStyle = dataGridViewCellStyle9;
             checkOutDataGrid.RowHeadersWidth = 82;
-            dataGridViewCellStyle6.Alignment = DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle6.Padding = new Padding(0, 0, 10, 0);
-            checkOutDataGrid.RowsDefaultCellStyle = dataGridViewCellStyle6;
+            checkOutDataGrid.RowsDefaultCellStyle = dataGridViewCellStyle6; // Will be updated
             checkOutDataGrid.RowTemplate.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleLeft;
             checkOutDataGrid.RowTemplate.DefaultCellStyle.Padding = new Padding(0, 0, 10, 0);
             checkOutDataGrid.RowTemplate.Resizable = DataGridViewTriState.True;
@@ -561,7 +863,7 @@ namespace grace
             // checkinPage
             // 
             checkinPage.AutoScroll = true;
-            checkinPage.BackColor = Color.Lavender;
+            checkinPage.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             checkinPage.Controls.Add(filterSkuLabel);
             checkinPage.Controls.Add(skuFilterTextBox);
             checkinPage.Controls.Add(allUsersCheckBox);
@@ -579,6 +881,8 @@ namespace grace
             // 
             filterSkuLabel.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             filterSkuLabel.AutoSize = true;
+            filterSkuLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            filterSkuLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             filterSkuLabel.Location = new Point(1306, 48);
             filterSkuLabel.Name = "filterSkuLabel";
             filterSkuLabel.Size = new Size(112, 18);
@@ -589,6 +893,10 @@ namespace grace
             // skuFilterTextBox
             // 
             skuFilterTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            skuFilterTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            skuFilterTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            skuFilterTextBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            skuFilterTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             skuFilterTextBox.Location = new Point(1306, 80);
             skuFilterTextBox.Name = "skuFilterTextBox";
             skuFilterTextBox.Size = new Size(194, 26);
@@ -598,6 +906,8 @@ namespace grace
             // 
             allUsersCheckBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             allUsersCheckBox.AutoSize = true;
+            allUsersCheckBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            allUsersCheckBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             allUsersCheckBox.Location = new Point(1351, 146);
             allUsersCheckBox.Name = "allUsersCheckBox";
             allUsersCheckBox.Size = new Size(149, 22);
@@ -609,16 +919,24 @@ namespace grace
             // 
             applyChangesButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             applyChangesButton.AutoSize = true;
+            applyChangesButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            applyChangesButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            applyChangesButton.FlatAppearance.BorderSize = 1;
+            applyChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            applyChangesButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            applyChangesButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             applyChangesButton.Location = new Point(1294, 202);
             applyChangesButton.Name = "applyChangesButton";
             applyChangesButton.Size = new Size(220, 35);
             applyChangesButton.TabIndex = 3;
             applyChangesButton.Text = "Apply Changes";
-            applyChangesButton.UseVisualStyleBackColor = true;
+            applyChangesButton.UseVisualStyleBackColor = false;
             // 
             // label3
             // 
             label3.AutoSize = true;
+            label3.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            label3.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label3.Location = new Point(1034, 38);
             label3.Name = "label3";
             label3.Size = new Size(0, 18);
@@ -626,15 +944,22 @@ namespace grace
             // 
             // checkInDataGrid
             // 
+            checkInDataGrid.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle10;
             checkInDataGrid.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             checkInDataGrid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells;
             checkInDataGrid.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells;
-            checkInDataGrid.BorderStyle = BorderStyle.Fixed3D;
-            checkInDataGrid.CellBorderStyle = DataGridViewCellBorderStyle.Sunken;
-            checkInDataGrid.ColumnHeadersBorderStyle = DataGridViewHeaderBorderStyle.Sunken;
+            checkInDataGrid.BackgroundColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
+            checkInDataGrid.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            checkInDataGrid.CellBorderStyle = DataGridViewCellBorderStyle.Sunken; // Keep or change to Single? For now, keep.
+            checkInDataGrid.ColumnHeadersBorderStyle = DataGridViewHeaderBorderStyle.Sunken; // Keep or change to Single? For now, keep.
+            checkInDataGrid.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle11;
             checkInDataGrid.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            checkInDataGrid.DefaultCellStyle = dataGridViewCellStyle12; // New style
+            checkInDataGrid.EnableHeadersVisualStyles = false;
+            checkInDataGrid.GridColor = System.Drawing.ColorTranslator.FromHtml("#D3C0B1");
             checkInDataGrid.Location = new Point(-7, 0);
             checkInDataGrid.Name = "checkInDataGrid";
+            checkInDataGrid.RowHeadersDefaultCellStyle = dataGridViewCellStyle13;
             checkInDataGrid.RowHeadersWidth = 82;
             checkInDataGrid.SelectionMode = DataGridViewSelectionMode.CellSelect;
             checkInDataGrid.Size = new Size(1292, 728);
@@ -642,7 +967,7 @@ namespace grace
             // 
             // reportPage
             // 
-            reportPage.BackColor = Color.Lavender;
+            reportPage.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             reportPage.Controls.Add(reportInfoLabel);
             reportPage.Controls.Add(filterLable);
             reportPage.Controls.Add(reportFilterTextBox);
@@ -658,7 +983,8 @@ namespace grace
             // reportInfoLabel
             // 
             reportInfoLabel.AutoSize = true;
-            reportInfoLabel.Font = new Font("Verdana", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 0);
+            reportInfoLabel.Font = new System.Drawing.Font("Georgia", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0))); // Heading Font
+            reportInfoLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             reportInfoLabel.Location = new Point(558, 21);
             reportInfoLabel.Name = "reportInfoLabel";
             reportInfoLabel.Size = new Size(582, 23);
@@ -669,7 +995,8 @@ namespace grace
             // filterLable
             // 
             filterLable.AutoSize = true;
-            filterLable.Font = new Font("Verdana", 13.875F, FontStyle.Bold, GraphicsUnit.Point, 0);
+            filterLable.Font = new System.Drawing.Font("Georgia", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0))); // Heading Font
+            filterLable.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             filterLable.Location = new Point(8, 18);
             filterLable.Name = "filterLable";
             filterLable.Size = new Size(132, 23);
@@ -678,7 +1005,10 @@ namespace grace
             // 
             // reportFilterTextBox
             // 
-            reportFilterTextBox.Font = new Font("Verdana", 13.875F, FontStyle.Bold, GraphicsUnit.Point, 0);
+            reportFilterTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            reportFilterTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            reportFilterTextBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            reportFilterTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             reportFilterTextBox.Location = new Point(157, 15);
             reportFilterTextBox.Name = "reportFilterTextBox";
             reportFilterTextBox.Size = new Size(235, 30);
@@ -686,27 +1016,41 @@ namespace grace
             // 
             // refreshButton
             // 
+            refreshButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            refreshButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            refreshButton.FlatAppearance.BorderSize = 1;
+            refreshButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            refreshButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            refreshButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             refreshButton.Location = new Point(431, 18);
             refreshButton.Name = "refreshButton";
             refreshButton.Size = new Size(97, 30);
             refreshButton.TabIndex = 5;
             refreshButton.Text = "Refresh";
-            refreshButton.UseVisualStyleBackColor = true;
+            refreshButton.UseVisualStyleBackColor = false;
             // 
             // reportGridView
             // 
+            reportGridView.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle14;
             reportGridView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             reportGridView.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells;
             reportGridView.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells;
+            reportGridView.BackgroundColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
+            reportGridView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            reportGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle15;
             reportGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            reportGridView.DefaultCellStyle = dataGridViewCellStyle16;
+            reportGridView.EnableHeadersVisualStyles = false;
+            reportGridView.GridColor = System.Drawing.ColorTranslator.FromHtml("#D3C0B1");
             reportGridView.Location = new Point(8, 60);
             reportGridView.Name = "reportGridView";
+            reportGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle17;
             reportGridView.Size = new Size(1501, 670);
             reportGridView.TabIndex = 0;
             // 
             // collectionPage
             // 
-            collectionPage.BackColor = Color.Lavender;
+            collectionPage.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             collectionPage.Controls.Add(clearComboButton);
             collectionPage.Controls.Add(colLabel1);
             collectionPage.Controls.Add(colReportComboBox);
@@ -720,16 +1064,24 @@ namespace grace
             // 
             // clearComboButton
             // 
+            clearComboButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            clearComboButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            clearComboButton.FlatAppearance.BorderSize = 1;
+            clearComboButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            clearComboButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            clearComboButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             clearComboButton.Location = new Point(436, 32);
             clearComboButton.Name = "clearComboButton";
             clearComboButton.Size = new Size(109, 26);
             clearComboButton.TabIndex = 3;
             clearComboButton.Text = "Clear";
-            clearComboButton.UseVisualStyleBackColor = true;
+            clearComboButton.UseVisualStyleBackColor = false;
             // 
             // colLabel1
             // 
             colLabel1.AutoSize = true;
+            colLabel1.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            colLabel1.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             colLabel1.Location = new Point(34, 35);
             colLabel1.Name = "colLabel1";
             colLabel1.Size = new Size(150, 18);
@@ -738,7 +1090,10 @@ namespace grace
             // 
             // colReportComboBox
             // 
-            colReportComboBox.FlatStyle = FlatStyle.Popup;
+            colReportComboBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            colReportComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            colReportComboBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            colReportComboBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             colReportComboBox.FormattingEnabled = true;
             colReportComboBox.Location = new Point(201, 32);
             colReportComboBox.Name = "colReportComboBox";
@@ -747,19 +1102,27 @@ namespace grace
             // 
             // collGridView
             // 
+            collGridView.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle18;
             collGridView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             collGridView.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells;
             collGridView.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells;
+            collGridView.BackgroundColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
+            collGridView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            collGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle19;
             collGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            collGridView.DefaultCellStyle = dataGridViewCellStyle20;
+            collGridView.EnableHeadersVisualStyles = false;
+            collGridView.GridColor = System.Drawing.ColorTranslator.FromHtml("#D3C0B1");
             collGridView.Location = new Point(6, 72);
             collGridView.Name = "collGridView";
+            collGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle21;
             collGridView.Size = new Size(1505, 655);
             collGridView.TabIndex = 0;
             // 
             // adminPage
             // 
             adminPage.AutoScroll = true;
-            adminPage.BackColor = Color.Lavender;
+            adminPage.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             adminPage.BorderStyle = BorderStyle.Fixed3D;
             adminPage.Controls.Add(adminCheckBox);
             adminPage.Controls.Add(adminUserLabel);
@@ -783,6 +1146,8 @@ namespace grace
             // adminCheckBox
             // 
             adminCheckBox.AutoSize = true;
+            adminCheckBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            adminCheckBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             adminCheckBox.Location = new Point(79, 402);
             adminCheckBox.Name = "adminCheckBox";
             adminCheckBox.Size = new Size(158, 22);
@@ -793,6 +1158,8 @@ namespace grace
             // adminUserLabel
             // 
             adminUserLabel.AutoSize = true;
+            adminUserLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            adminUserLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             adminUserLabel.Location = new Point(256, 58);
             adminUserLabel.Name = "adminUserLabel";
             adminUserLabel.Size = new Size(203, 18);
@@ -802,6 +1169,8 @@ namespace grace
             // label5
             // 
             label5.AutoSize = true;
+            label5.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            label5.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label5.Location = new Point(137, 98);
             label5.Name = "label5";
             label5.Size = new Size(84, 18);
@@ -810,10 +1179,12 @@ namespace grace
             // 
             // resetComboBox
             // 
-            resetComboBox.BackColor = Color.White;
+            resetComboBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
             resetComboBox.DrawMode = DrawMode.OwnerDrawFixed;
             resetComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
-            resetComboBox.Font = new Font("Verdana", 11.25F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            resetComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            resetComboBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            resetComboBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             resetComboBox.FormattingEnabled = true;
             resetComboBox.Location = new Point(255, 94);
             resetComboBox.Name = "resetComboBox";
@@ -823,18 +1194,24 @@ namespace grace
             // 
             // deleteUserButton
             // 
-            deleteUserButton.FlatStyle = FlatStyle.Popup;
+            deleteUserButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            deleteUserButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            deleteUserButton.FlatAppearance.BorderSize = 1;
+            deleteUserButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat; // Changed from Popup
+            deleteUserButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            deleteUserButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             deleteUserButton.Location = new Point(79, 239);
             deleteUserButton.Name = "deleteUserButton";
             deleteUserButton.Size = new Size(370, 50);
             deleteUserButton.TabIndex = 8;
             deleteUserButton.Text = "Delete User";
-            deleteUserButton.UseVisualStyleBackColor = true;
+            deleteUserButton.UseVisualStyleBackColor = false; // Changed from true
             // 
             // label9
             // 
             label9.AutoSize = true;
-            label9.Font = new Font("Verdana", 14.25F, FontStyle.Bold);
+            label9.Font = new System.Drawing.Font("Georgia", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0))); // Heading Font
+            label9.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label9.Location = new Point(1089, 34);
             label9.Name = "label9";
             label9.Size = new Size(224, 23);
@@ -843,19 +1220,28 @@ namespace grace
             // 
             // resetPasswordButton
             // 
-            resetPasswordButton.FlatStyle = FlatStyle.Popup;
+            resetPasswordButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            resetPasswordButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            resetPasswordButton.FlatAppearance.BorderSize = 1;
+            resetPasswordButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat; // Changed from Popup
+            resetPasswordButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            resetPasswordButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             resetPasswordButton.Location = new Point(79, 164);
             resetPasswordButton.Name = "resetPasswordButton";
             resetPasswordButton.Size = new Size(380, 53);
             resetPasswordButton.TabIndex = 2;
             resetPasswordButton.Text = "Reset Password";
-            resetPasswordButton.UseVisualStyleBackColor = true;
+            resetPasswordButton.UseVisualStyleBackColor = false; // Changed from true
             // 
             // addUserButton
             // 
             addUserButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            addUserButton.BackColor = Color.Lavender;
-            addUserButton.FlatStyle = FlatStyle.Popup;
+            addUserButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5"); // Changed from Lavender
+            addUserButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            addUserButton.FlatAppearance.BorderSize = 1;
+            addUserButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat; // Changed from Popup
+            addUserButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            addUserButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             addUserButton.Location = new Point(79, 318);
             addUserButton.Margin = new Padding(4, 6, 4, 6);
             addUserButton.Name = "addUserButton";
@@ -867,10 +1253,10 @@ namespace grace
             // loggingTextBox
             // 
             loggingTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Right;
-            loggingTextBox.BackColor = Color.FromArgb(255, 255, 255);
-            loggingTextBox.BorderStyle = BorderStyle.FixedSingle;
-            loggingTextBox.Font = new Font("Microsoft Sans Serif", 14F, FontStyle.Regular, GraphicsUnit.Pixel);
-            loggingTextBox.ForeColor = Color.FromArgb(222, 0, 0, 0);
+            loggingTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0"); // FloralWhite
+            loggingTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            loggingTextBox.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            loggingTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F"); // Charcoal
             loggingTextBox.Location = new Point(647, 97);
             loggingTextBox.Multiline = true;
             loggingTextBox.Name = "loggingTextBox";
@@ -881,26 +1267,36 @@ namespace grace
             // restoreDatabaseButton
             // 
             restoreDatabaseButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            restoreDatabaseButton.FlatStyle = FlatStyle.Popup;
+            restoreDatabaseButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            restoreDatabaseButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            restoreDatabaseButton.FlatAppearance.BorderSize = 1;
+            restoreDatabaseButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat; // Changed from Popup
+            restoreDatabaseButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            restoreDatabaseButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             restoreDatabaseButton.Location = new Point(36, 516);
             restoreDatabaseButton.Margin = new Padding(4, 6, 4, 6);
             restoreDatabaseButton.Name = "restoreDatabaseButton";
             restoreDatabaseButton.Size = new Size(216, 56);
             restoreDatabaseButton.TabIndex = 5;
             restoreDatabaseButton.Text = "Restore Database";
-            restoreDatabaseButton.UseVisualStyleBackColor = true;
+            restoreDatabaseButton.UseVisualStyleBackColor = false; // Changed from true
             // 
             // backupButton
             // 
             backupButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            backupButton.FlatStyle = FlatStyle.Popup;
+            backupButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            backupButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            backupButton.FlatAppearance.BorderSize = 1;
+            backupButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat; // Changed from Popup
+            backupButton.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            backupButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             backupButton.Location = new Point(36, 455);
             backupButton.Margin = new Padding(4, 6, 4, 6);
             backupButton.Name = "backupButton";
             backupButton.Size = new Size(216, 49);
             backupButton.TabIndex = 4;
             backupButton.Text = "Backup Database";
-            backupButton.UseVisualStyleBackColor = true;
+            backupButton.UseVisualStyleBackColor = false; // Changed from true
             // 
             // errorProvider1
             // 
@@ -917,11 +1313,11 @@ namespace grace
             AutoScaleDimensions = new SizeF(7F, 17F);
             AutoScaleMode = AutoScaleMode.Font;
             AutoScroll = true;
-            BackColor = Color.White;
+            BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             ClientSize = new Size(1539, 823);
             Controls.Add(tabControl);
             Controls.Add(menuStrip1);
-            Font = new Font("Segoe UI", 10.125F);
+            Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             Icon = (Icon)resources.GetObject("$this.Icon");
             MainMenuStrip = menuStrip1;
             Margin = new Padding(5, 2, 5, 2);

--- a/grace/dialogs/AddUserDialog.Designer.cs
+++ b/grace/dialogs/AddUserDialog.Designer.cs
@@ -40,18 +40,27 @@
             // 
             // saveButton
             // 
-            saveButton.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            saveButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            saveButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            saveButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            saveButton.FlatAppearance.BorderSize = 1;
+            saveButton.FlatStyle = FlatStyle.Flat;
+            saveButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            saveButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             saveButton.Location = new Point(48, 235);
             saveButton.Name = "saveButton";
             saveButton.Size = new Size(75, 28);
             saveButton.TabIndex = 0;
             saveButton.Text = "Save";
-            saveButton.UseVisualStyleBackColor = true;
+            saveButton.UseVisualStyleBackColor = false;
             saveButton.Click += saveButton_Click;
             // 
             // usernameTextBox
             // 
-            usernameTextBox.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+            usernameTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            usernameTextBox.BorderStyle = BorderStyle.FixedSingle;
+            usernameTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            usernameTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             usernameTextBox.Location = new Point(149, 46);
             usernameTextBox.Name = "usernameTextBox";
             usernameTextBox.Size = new Size(140, 25);
@@ -60,7 +69,8 @@
             // label1
             // 
             label1.AutoSize = true;
-            label1.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label1.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label1.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label1.Location = new Point(54, 47);
             label1.Name = "label1";
             label1.Size = new Size(69, 17);
@@ -72,6 +82,8 @@
             forcePasswordUpdateCheckBox.AutoSize = true;
             forcePasswordUpdateCheckBox.Checked = true;
             forcePasswordUpdateCheckBox.CheckState = CheckState.Checked;
+            forcePasswordUpdateCheckBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            forcePasswordUpdateCheckBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             forcePasswordUpdateCheckBox.Location = new Point(54, 146);
             forcePasswordUpdateCheckBox.Name = "forcePasswordUpdateCheckBox";
             forcePasswordUpdateCheckBox.Size = new Size(178, 19);
@@ -82,7 +94,8 @@
             // label2
             // 
             label2.AutoSize = true;
-            label2.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label2.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label2.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label2.Location = new Point(54, 91);
             label2.Name = "label2";
             label2.Size = new Size(66, 17);
@@ -91,7 +104,10 @@
             // 
             // passwordTextBox
             // 
-            passwordTextBox.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+            passwordTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            passwordTextBox.BorderStyle = BorderStyle.FixedSingle;
+            passwordTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            passwordTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             passwordTextBox.Location = new Point(149, 90);
             passwordTextBox.Name = "passwordTextBox";
             passwordTextBox.Size = new Size(140, 25);
@@ -101,6 +117,8 @@
             // adminCheckBox
             // 
             adminCheckBox.AutoSize = true;
+            adminCheckBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            adminCheckBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             adminCheckBox.Location = new Point(54, 182);
             adminCheckBox.Name = "adminCheckBox";
             adminCheckBox.Size = new Size(120, 19);
@@ -110,18 +128,25 @@
             // 
             // cancelButton
             // 
-            cancelButton.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
-            cancelButton.Location = new Point(170, 235);
+            cancelButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            cancelButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            cancelButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            cancelButton.FlatAppearance.BorderSize = 1;
+            cancelButton.FlatStyle = FlatStyle.Flat;
+            cancelButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            cancelButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            cancelButton.Location = new Point(310, 235); // Adjusted X for Right anchor
             cancelButton.Name = "cancelButton";
             cancelButton.Size = new Size(75, 28);
             cancelButton.TabIndex = 7;
             cancelButton.Text = "Cancel";
-            cancelButton.UseVisualStyleBackColor = true;
+            cancelButton.UseVisualStyleBackColor = false;
             // 
             // AddUserDialog
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             CancelButton = cancelButton;
             ClientSize = new Size(432, 309);
             Controls.Add(cancelButton);
@@ -132,6 +157,8 @@
             Controls.Add(label1);
             Controls.Add(usernameTextBox);
             Controls.Add(saveButton);
+            Font = new System.Drawing.Font("Segoe UI", 10F);
+            ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             Name = "AddUserDialog";
             ShowIcon = false;
             ShowInTaskbar = false;

--- a/grace/dialogs/CheckInDialog.Designer.cs
+++ b/grace/dialogs/CheckInDialog.Designer.cs
@@ -45,27 +45,43 @@
             // 
             // updateButton
             // 
-            updateButton.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            updateButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            updateButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            updateButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            updateButton.FlatAppearance.BorderSize = 1;
+            updateButton.FlatStyle = FlatStyle.Flat;
+            updateButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            updateButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             updateButton.Location = new Point(19, 246);
             updateButton.Name = "updateButton";
             updateButton.Size = new Size(95, 34);
             updateButton.TabIndex = 3;
             updateButton.Text = "Update";
-            updateButton.UseVisualStyleBackColor = true;
+            updateButton.UseVisualStyleBackColor = false;
             updateButton.Click += UpdateButton_Click;
             // 
             // deleteButton
             // 
-            deleteButton.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            deleteButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            deleteButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            deleteButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            deleteButton.FlatAppearance.BorderSize = 1;
+            deleteButton.FlatStyle = FlatStyle.Flat;
+            deleteButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            deleteButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             deleteButton.Location = new Point(135, 246);
             deleteButton.Name = "deleteButton";
             deleteButton.Size = new Size(95, 34);
             deleteButton.TabIndex = 4;
             deleteButton.Text = "Delete";
-            deleteButton.UseVisualStyleBackColor = true;
+            deleteButton.UseVisualStyleBackColor = false;
             // 
             // userTotalTextBox
             // 
+            userTotalTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            userTotalTextBox.BorderStyle = BorderStyle.FixedSingle;
+            userTotalTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            userTotalTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             userTotalTextBox.Location = new Point(135, 172);
             userTotalTextBox.Name = "userTotalTextBox";
             userTotalTextBox.Size = new Size(198, 23);
@@ -74,7 +90,8 @@
             // label1
             // 
             label1.AutoSize = true;
-            label1.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label1.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label1.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label1.Location = new Point(28, 175);
             label1.Name = "label1";
             label1.Size = new Size(86, 17);
@@ -84,7 +101,8 @@
             // label2
             // 
             label2.AutoSize = true;
-            label2.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label2.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label2.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label2.Location = new Point(44, 136);
             label2.Name = "label2";
             label2.Size = new Size(70, 17);
@@ -93,6 +111,10 @@
             // 
             // collectionComboBox
             // 
+            collectionComboBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            collectionComboBox.FlatStyle = FlatStyle.Flat;
+            collectionComboBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            collectionComboBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             collectionComboBox.FormattingEnabled = true;
             collectionComboBox.Location = new Point(135, 135);
             collectionComboBox.Name = "collectionComboBox";
@@ -102,7 +124,8 @@
             // label3
             // 
             label3.AutoSize = true;
-            label3.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label3.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label3.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label3.Location = new Point(82, 29);
             label3.Name = "label3";
             label3.Size = new Size(32, 17);
@@ -112,7 +135,8 @@
             // skuLabel
             // 
             skuLabel.AutoSize = true;
-            skuLabel.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            skuLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            skuLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             skuLabel.Location = new Point(135, 29);
             skuLabel.Name = "skuLabel";
             skuLabel.Size = new Size(32, 17);
@@ -122,7 +146,8 @@
             // descriptionLabel
             // 
             descriptionLabel.AutoSize = true;
-            descriptionLabel.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            descriptionLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            descriptionLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             descriptionLabel.Location = new Point(135, 85);
             descriptionLabel.Name = "descriptionLabel";
             descriptionLabel.Size = new Size(32, 17);
@@ -132,7 +157,8 @@
             // label5
             // 
             label5.AutoSize = true;
-            label5.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label5.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label5.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label5.Location = new Point(35, 85);
             label5.Name = "label5";
             label5.Size = new Size(79, 17);
@@ -142,7 +168,8 @@
             // brandLabel
             // 
             brandLabel.AutoSize = true;
-            brandLabel.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            brandLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            brandLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             brandLabel.Location = new Point(135, 58);
             brandLabel.Name = "brandLabel";
             brandLabel.Size = new Size(32, 17);
@@ -152,7 +179,8 @@
             // label7
             // 
             label7.AutoSize = true;
-            label7.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label7.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label7.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label7.Location = new Point(70, 58);
             label7.Name = "label7";
             label7.Size = new Size(44, 17);
@@ -161,18 +189,25 @@
             // 
             // cancelButton
             // 
-            cancelButton.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
-            cancelButton.Location = new Point(254, 246);
+            cancelButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            cancelButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            cancelButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            cancelButton.FlatAppearance.BorderSize = 1;
+            cancelButton.FlatStyle = FlatStyle.Flat;
+            cancelButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            cancelButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            cancelButton.Location = new Point(297, 246); // Adjusted X for Right anchor
             cancelButton.Name = "cancelButton";
             cancelButton.Size = new Size(95, 34);
             cancelButton.TabIndex = 5;
             cancelButton.Text = "Cancel";
-            cancelButton.UseVisualStyleBackColor = true;
+            cancelButton.UseVisualStyleBackColor = false;
             // 
             // CheckInDialog
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             CancelButton = cancelButton;
             ClientSize = new Size(404, 323);
             Controls.Add(cancelButton);
@@ -188,6 +223,8 @@
             Controls.Add(userTotalTextBox);
             Controls.Add(deleteButton);
             Controls.Add(updateButton);
+            Font = new System.Drawing.Font("Segoe UI", 10F);
+            ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             Name = "CheckInDialog";
             ShowIcon = false;
             ShowInTaskbar = false;

--- a/grace/dialogs/CheckOutForm.Designer.cs
+++ b/grace/dialogs/CheckOutForm.Designer.cs
@@ -52,7 +52,8 @@
             // label1
             // 
             label1.AutoSize = true;
-            label1.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label1.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label1.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label1.Location = new Point(94, 95);
             label1.Name = "label1";
             label1.Size = new Size(44, 17);
@@ -62,7 +63,8 @@
             // brandLabel
             // 
             brandLabel.AutoSize = true;
-            brandLabel.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+            brandLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            brandLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             brandLabel.Location = new Point(148, 95);
             brandLabel.Name = "brandLabel";
             brandLabel.Size = new Size(29, 17);
@@ -72,7 +74,8 @@
             // label2
             // 
             label2.AutoSize = true;
-            label2.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label2.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label2.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label2.Location = new Point(48, 141);
             label2.Name = "label2";
             label2.Size = new Size(90, 17);
@@ -82,7 +85,8 @@
             // skuLabel
             // 
             skuLabel.AutoSize = true;
-            skuLabel.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+            skuLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            skuLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             skuLabel.Location = new Point(148, 141);
             skuLabel.Name = "skuLabel";
             skuLabel.Size = new Size(29, 17);
@@ -92,7 +96,8 @@
             // descriptionLabel
             // 
             descriptionLabel.AutoSize = true;
-            descriptionLabel.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+            descriptionLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            descriptionLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             descriptionLabel.Location = new Point(148, 193);
             descriptionLabel.Name = "descriptionLabel";
             descriptionLabel.Size = new Size(29, 17);
@@ -102,7 +107,8 @@
             // label4
             // 
             label4.AutoSize = true;
-            label4.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label4.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label4.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label4.Location = new Point(59, 193);
             label4.Name = "label4";
             label4.Size = new Size(79, 17);
@@ -112,7 +118,8 @@
             // totalLabel
             // 
             totalLabel.AutoSize = true;
-            totalLabel.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+            totalLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            totalLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             totalLabel.Location = new Point(148, 241);
             totalLabel.Name = "totalLabel";
             totalLabel.Size = new Size(29, 17);
@@ -122,7 +129,8 @@
             // label5
             // 
             label5.AutoSize = true;
-            label5.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label5.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label5.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label5.Location = new Point(12, 241);
             label5.Name = "label5";
             label5.Size = new Size(126, 17);
@@ -132,7 +140,8 @@
             // label3
             // 
             label3.AutoSize = true;
-            label3.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label3.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label3.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label3.Location = new Point(310, 97);
             label3.Name = "label3";
             label3.Size = new Size(138, 17);
@@ -142,7 +151,8 @@
             // label6
             // 
             label6.AutoSize = true;
-            label6.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label6.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label6.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label6.Location = new Point(342, 149);
             label6.Name = "label6";
             label6.Size = new Size(106, 17);
@@ -152,7 +162,11 @@
             // 
             // numCheckOutTextBox
             // 
-            numCheckOutTextBox.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+            numCheckOutTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            numCheckOutTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            numCheckOutTextBox.BorderStyle = BorderStyle.FixedSingle;
+            numCheckOutTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            numCheckOutTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             numCheckOutTextBox.Location = new Point(489, 87);
             numCheckOutTextBox.Name = "numCheckOutTextBox";
             numCheckOutTextBox.Size = new Size(121, 25);
@@ -161,7 +175,11 @@
             // 
             // collectionComboBox
             // 
-            collectionComboBox.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+            collectionComboBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            collectionComboBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            collectionComboBox.FlatStyle = FlatStyle.Flat;
+            collectionComboBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            collectionComboBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             collectionComboBox.FormattingEnabled = true;
             collectionComboBox.Location = new Point(489, 141);
             collectionComboBox.Name = "collectionComboBox";
@@ -171,30 +189,46 @@
             // 
             // saveButton
             // 
-            saveButton.Font = new Font("Segoe UI", 12F, FontStyle.Bold, GraphicsUnit.Point);
+            saveButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            saveButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            saveButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            saveButton.FlatAppearance.BorderSize = 1;
+            saveButton.FlatStyle = FlatStyle.Flat;
+            saveButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            saveButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             saveButton.Location = new Point(133, 308);
             saveButton.Name = "saveButton";
             saveButton.Size = new Size(90, 43);
             saveButton.TabIndex = 12;
             saveButton.Text = "Save";
-            saveButton.UseVisualStyleBackColor = true;
+            saveButton.UseVisualStyleBackColor = false;
             saveButton.Click += SaveButton_Click;
             // 
             // cancelButton
             // 
-            cancelButton.Font = new Font("Segoe UI", 12F, FontStyle.Bold, GraphicsUnit.Point);
-            cancelButton.Location = new Point(269, 308);
+            cancelButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            cancelButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            cancelButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            cancelButton.FlatAppearance.BorderSize = 1;
+            cancelButton.FlatStyle = FlatStyle.Flat;
+            cancelButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            cancelButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            cancelButton.Location = new Point(520, 308); // Adjusted X for Right anchor
             cancelButton.Name = "cancelButton";
             cancelButton.Size = new Size(90, 43);
             cancelButton.TabIndex = 13;
             cancelButton.Text = "Cancel";
-            cancelButton.UseVisualStyleBackColor = true;
+            cancelButton.UseVisualStyleBackColor = false;
             cancelButton.Click += cancelButton_Click;
             // 
             // commentBox
             // 
             commentBox.AcceptsReturn = true;
-            commentBox.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point);
+            commentBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            commentBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            commentBox.BorderStyle = BorderStyle.FixedSingle;
+            commentBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            commentBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             commentBox.Location = new Point(489, 210);
             commentBox.Multiline = true;
             commentBox.Name = "commentBox";
@@ -204,7 +238,8 @@
             // label7
             // 
             label7.AutoSize = true;
-            label7.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            label7.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label7.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label7.Location = new Point(389, 210);
             label7.Name = "label7";
             label7.Size = new Size(68, 17);
@@ -213,8 +248,9 @@
             // 
             // CheckOutForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             ClientSize = new Size(658, 377);
             Controls.Add(label7);
             Controls.Add(commentBox);
@@ -232,6 +268,8 @@
             Controls.Add(label2);
             Controls.Add(brandLabel);
             Controls.Add(label1);
+            Font = new System.Drawing.Font("Segoe UI", 10F);
+            ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             Name = "CheckOutForm";
             ShowIcon = false;
             ShowInTaskbar = false;

--- a/grace/dialogs/EditRowForm.Designer.cs
+++ b/grace/dialogs/EditRowForm.Designer.cs
@@ -64,18 +64,26 @@ namespace grace
             // 
             // cancelButton
             // 
-            cancelButton.Font = new Font("Segoe UI", 11.25F);
-            cancelButton.Location = new Point(452, 512);
+            cancelButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            cancelButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            cancelButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            cancelButton.FlatAppearance.BorderSize = 1;
+            cancelButton.FlatStyle = FlatStyle.Flat;
+            cancelButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            cancelButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            cancelButton.Location = new Point(699, 512); // Adjusted X for Right anchor (858 - 113 - approx 40 for padding)
             cancelButton.Margin = new Padding(2, 1, 2, 1);
             cancelButton.Name = "cancelButton";
             cancelButton.Size = new Size(113, 33);
             cancelButton.TabIndex = 11;
             cancelButton.Text = "Cancel";
-            cancelButton.UseVisualStyleBackColor = true;
+            cancelButton.UseVisualStyleBackColor = false;
             cancelButton.Click += cancelButton_Click;
             // 
             // panel1
             // 
+            panel1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            panel1.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE"); // Blend with form
             panel1.BorderStyle = BorderStyle.FixedSingle;
             panel1.Controls.Add(noteTextBox);
             panel1.Controls.Add(label9);
@@ -105,16 +113,22 @@ namespace grace
             // 
             // noteTextBox
             // 
+            noteTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            noteTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            noteTextBox.BorderStyle = BorderStyle.FixedSingle;
+            noteTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            noteTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             noteTextBox.Location = new Point(146, 294);
             noteTextBox.Multiline = true;
             noteTextBox.Name = "noteTextBox";
-            noteTextBox.Size = new Size(269, 67);
+            noteTextBox.Size = new Size(269, 67); // Width will be adjusted by anchor
             noteTextBox.TabIndex = 31;
             // 
             // label9
             // 
             label9.AutoSize = true;
-            label9.Font = new Font("Segoe UI", 9.75F);
+            label9.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label9.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label9.Location = new Point(26, 295);
             label9.Name = "label9";
             label9.Size = new Size(37, 17);
@@ -124,7 +138,8 @@ namespace grace
             // addCollectionLabel
             // 
             addCollectionLabel.AutoSize = true;
-            addCollectionLabel.Font = new Font("Segoe UI", 10.125F);
+            addCollectionLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            addCollectionLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             addCollectionLabel.Location = new Point(433, 336);
             addCollectionLabel.Margin = new Padding(2, 0, 2, 0);
             addCollectionLabel.Name = "addCollectionLabel";
@@ -136,7 +151,11 @@ namespace grace
             // 
             // addCollectionTextBox
             // 
-            addCollectionTextBox.Font = new Font("Segoe UI", 10.125F);
+            addCollectionTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            addCollectionTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            addCollectionTextBox.BorderStyle = BorderStyle.FixedSingle;
+            addCollectionTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            addCollectionTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             addCollectionTextBox.Location = new Point(581, 336);
             addCollectionTextBox.Margin = new Padding(2, 1, 2, 1);
             addCollectionTextBox.Name = "addCollectionTextBox";
@@ -147,6 +166,11 @@ namespace grace
             // 
             // checkedListBox
             // 
+            checkedListBox.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Right;
+            checkedListBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            checkedListBox.BorderStyle = BorderStyle.FixedSingle;
+            checkedListBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            checkedListBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             checkedListBox.FormattingEnabled = true;
             checkedListBox.Location = new Point(581, 38);
             checkedListBox.Name = "checkedListBox";
@@ -156,9 +180,11 @@ namespace grace
             // 
             // label8
             // 
+            label8.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
             label8.AutoSize = true;
             label8.BorderStyle = BorderStyle.FixedSingle;
-            label8.Font = new Font("Segoe UI", 12F, FontStyle.Bold);
+            label8.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            label8.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label8.Location = new Point(17, 389);
             label8.Name = "label8";
             label8.Size = new Size(254, 23);
@@ -168,7 +194,8 @@ namespace grace
             // collectionLabel
             // 
             collectionLabel.AutoSize = true;
-            collectionLabel.Font = new Font("Segoe UI", 14.25F, FontStyle.Bold);
+            collectionLabel.Font = new System.Drawing.Font("Georgia", 11F, FontStyle.Bold);
+            collectionLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             collectionLabel.Location = new Point(581, 10);
             collectionLabel.Name = "collectionLabel";
             collectionLabel.Size = new Size(109, 25);
@@ -177,7 +204,10 @@ namespace grace
             // 
             // brandComboBox
             // 
-            brandComboBox.Font = new Font("Segoe UI", 9.75F);
+            brandComboBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            brandComboBox.FlatStyle = FlatStyle.Flat;
+            brandComboBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            brandComboBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             brandComboBox.FormattingEnabled = true;
             brandComboBox.Location = new Point(267, 52);
             brandComboBox.Name = "brandComboBox";
@@ -186,7 +216,10 @@ namespace grace
             // 
             // adjustTextBox
             // 
-            adjustTextBox.Font = new Font("Segoe UI", 9.75F);
+            adjustTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            adjustTextBox.BorderStyle = BorderStyle.FixedSingle;
+            adjustTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            adjustTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             adjustTextBox.Location = new Point(265, 241);
             adjustTextBox.Name = "adjustTextBox";
             adjustTextBox.Size = new Size(150, 25);
@@ -195,7 +228,8 @@ namespace grace
             // adjustInventoryLabel
             // 
             adjustInventoryLabel.AutoSize = true;
-            adjustInventoryLabel.Font = new Font("Segoe UI", 10.125F, FontStyle.Bold);
+            adjustInventoryLabel.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            adjustInventoryLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             adjustInventoryLabel.Location = new Point(17, 247);
             adjustInventoryLabel.Name = "adjustInventoryLabel";
             adjustInventoryLabel.Size = new Size(228, 19);
@@ -205,7 +239,10 @@ namespace grace
             // 
             // currentTextBox
             // 
-            currentTextBox.Font = new Font("Segoe UI", 9.75F);
+            currentTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            currentTextBox.BorderStyle = BorderStyle.FixedSingle;
+            currentTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            currentTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             currentTextBox.Location = new Point(265, 193);
             currentTextBox.Name = "currentTextBox";
             currentTextBox.ReadOnly = true;
@@ -215,7 +252,8 @@ namespace grace
             // label6
             // 
             label6.AutoSize = true;
-            label6.Font = new Font("Segoe UI", 9.75F);
+            label6.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label6.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label6.Location = new Point(17, 201);
             label6.Name = "label6";
             label6.Size = new Size(108, 17);
@@ -224,7 +262,10 @@ namespace grace
             // 
             // barCodeTextBox
             // 
-            barCodeTextBox.Font = new Font("Segoe UI", 9.75F);
+            barCodeTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            barCodeTextBox.BorderStyle = BorderStyle.FixedSingle;
+            barCodeTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            barCodeTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             barCodeTextBox.Location = new Point(265, 159);
             barCodeTextBox.Name = "barCodeTextBox";
             barCodeTextBox.Size = new Size(150, 25);
@@ -233,7 +274,10 @@ namespace grace
             // 
             // availabilityTextBox
             // 
-            availabilityTextBox.Font = new Font("Segoe UI", 9.75F);
+            availabilityTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            availabilityTextBox.BorderStyle = BorderStyle.FixedSingle;
+            availabilityTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            availabilityTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             availabilityTextBox.Location = new Point(265, 121);
             availabilityTextBox.Name = "availabilityTextBox";
             availabilityTextBox.Size = new Size(150, 25);
@@ -242,7 +286,8 @@ namespace grace
             // label5
             // 
             label5.AutoSize = true;
-            label5.Font = new Font("Segoe UI", 9.75F);
+            label5.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label5.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label5.Location = new Point(17, 162);
             label5.Name = "label5";
             label5.Size = new Size(62, 17);
@@ -252,7 +297,8 @@ namespace grace
             // label4
             // 
             label4.AutoSize = true;
-            label4.Font = new Font("Segoe UI", 9.75F);
+            label4.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label4.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label4.Location = new Point(17, 124);
             label4.Name = "label4";
             label4.Size = new Size(95, 17);
@@ -261,7 +307,10 @@ namespace grace
             // 
             // descTextBox
             // 
-            descTextBox.Font = new Font("Segoe UI", 9.75F);
+            descTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            descTextBox.BorderStyle = BorderStyle.FixedSingle;
+            descTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            descTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             descTextBox.Location = new Point(146, 87);
             descTextBox.Name = "descTextBox";
             descTextBox.Size = new Size(269, 25);
@@ -270,7 +319,8 @@ namespace grace
             // label3
             // 
             label3.AutoSize = true;
-            label3.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold);
+            label3.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            label3.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label3.Location = new Point(17, 90);
             label3.Name = "label3";
             label3.Size = new Size(79, 17);
@@ -279,7 +329,10 @@ namespace grace
             // 
             // skuTextBox
             // 
-            skuTextBox.Font = new Font("Segoe UI", 9.75F);
+            skuTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            skuTextBox.BorderStyle = BorderStyle.FixedSingle;
+            skuTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            skuTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             skuTextBox.Location = new Point(265, 15);
             skuTextBox.Name = "skuTextBox";
             skuTextBox.Size = new Size(150, 25);
@@ -289,7 +342,8 @@ namespace grace
             // label2
             // 
             label2.AutoSize = true;
-            label2.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold);
+            label2.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            label2.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label2.Location = new Point(17, 55);
             label2.Name = "label2";
             label2.Size = new Size(44, 17);
@@ -299,7 +353,8 @@ namespace grace
             // label1
             // 
             label1.AutoSize = true;
-            label1.Font = new Font("Segoe UI", 9.75F, FontStyle.Bold);
+            label1.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            label1.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label1.Location = new Point(17, 18);
             label1.Name = "label1";
             label1.Size = new Size(32, 17);
@@ -308,26 +363,38 @@ namespace grace
             // 
             // saveButton
             // 
-            saveButton.Font = new Font("Segoe UI", 11.25F);
+            saveButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            saveButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            saveButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            saveButton.FlatAppearance.BorderSize = 1;
+            saveButton.FlatStyle = FlatStyle.Flat;
+            saveButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            saveButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             saveButton.Location = new Point(40, 512);
             saveButton.Margin = new Padding(2, 1, 2, 1);
             saveButton.Name = "saveButton";
             saveButton.Size = new Size(113, 33);
             saveButton.TabIndex = 9;
             saveButton.Text = "Update";
-            saveButton.UseVisualStyleBackColor = true;
+            saveButton.UseVisualStyleBackColor = false;
             saveButton.Click += SaveButton_Click;
             // 
             // deleteButton
             // 
-            deleteButton.Font = new Font("Segoe UI", 11.25F);
+            deleteButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            deleteButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            deleteButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            deleteButton.FlatAppearance.BorderSize = 1;
+            deleteButton.FlatStyle = FlatStyle.Flat;
+            deleteButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            deleteButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             deleteButton.Location = new Point(241, 512);
             deleteButton.Margin = new Padding(2, 1, 2, 1);
             deleteButton.Name = "deleteButton";
             deleteButton.Size = new Size(113, 33);
             deleteButton.TabIndex = 10;
             deleteButton.Text = "Delete";
-            deleteButton.UseVisualStyleBackColor = true;
+            deleteButton.UseVisualStyleBackColor = false;
             deleteButton.Click += DeleteButton_Click;
             // 
             // toolTip
@@ -336,8 +403,9 @@ namespace grace
             // 
             // EditRowForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             CancelButton = cancelButton;
             ClientSize = new Size(858, 571);
             Controls.Add(deleteButton);

--- a/grace/dialogs/PasswordChange.Designer.cs
+++ b/grace/dialogs/PasswordChange.Designer.cs
@@ -44,6 +44,8 @@
             // chkShowNewPassword
             // 
             chkShowNewPassword.AutoSize = true;
+            chkShowNewPassword.Font = new System.Drawing.Font("Segoe UI", 10F);
+            chkShowNewPassword.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             chkShowNewPassword.Location = new Point(312, 185);
             chkShowNewPassword.Name = "chkShowNewPassword";
             chkShowNewPassword.Size = new Size(108, 19);
@@ -55,6 +57,8 @@
             // chkShowOrginalPassword
             // 
             chkShowOrginalPassword.AutoSize = true;
+            chkShowOrginalPassword.Font = new System.Drawing.Font("Segoe UI", 10F);
+            chkShowOrginalPassword.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             chkShowOrginalPassword.Location = new Point(312, 140);
             chkShowOrginalPassword.Name = "chkShowOrginalPassword";
             chkShowOrginalPassword.Size = new Size(108, 19);
@@ -66,6 +70,8 @@
             // label4
             // 
             label4.AutoSize = true;
+            label4.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label4.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label4.Location = new Point(43, 184);
             label4.Name = "label4";
             label4.Size = new Size(84, 15);
@@ -75,6 +81,8 @@
             // label3
             // 
             label3.AutoSize = true;
+            label3.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label3.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label3.Location = new Point(23, 227);
             label3.Name = "label3";
             label3.Size = new Size(104, 15);
@@ -84,6 +92,8 @@
             // currentPasswordLabel
             // 
             currentPasswordLabel.AutoSize = true;
+            currentPasswordLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            currentPasswordLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             currentPasswordLabel.Location = new Point(27, 141);
             currentPasswordLabel.Name = "currentPasswordLabel";
             currentPasswordLabel.Size = new Size(100, 15);
@@ -92,6 +102,10 @@
             // 
             // newPasswordTextBox
             // 
+            newPasswordTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            newPasswordTextBox.BorderStyle = BorderStyle.FixedSingle;
+            newPasswordTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            newPasswordTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             newPasswordTextBox.Location = new Point(138, 181);
             newPasswordTextBox.Name = "newPasswordTextBox";
             newPasswordTextBox.PasswordChar = '*';
@@ -100,6 +114,10 @@
             // 
             // confirmTextBox
             // 
+            confirmTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            confirmTextBox.BorderStyle = BorderStyle.FixedSingle;
+            confirmTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            confirmTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             confirmTextBox.Location = new Point(138, 224);
             confirmTextBox.Name = "confirmTextBox";
             confirmTextBox.PasswordChar = '*';
@@ -109,6 +127,10 @@
             // 
             // currentPasswordTextBox
             // 
+            currentPasswordTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            currentPasswordTextBox.BorderStyle = BorderStyle.FixedSingle;
+            currentPasswordTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            currentPasswordTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             currentPasswordTextBox.Location = new Point(138, 138);
             currentPasswordTextBox.Name = "currentPasswordTextBox";
             currentPasswordTextBox.PasswordChar = '*';
@@ -117,27 +139,43 @@
             // 
             // saveButton
             // 
+            saveButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            saveButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            saveButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            saveButton.FlatAppearance.BorderSize = 1;
+            saveButton.FlatStyle = FlatStyle.Flat;
+            saveButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            saveButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             saveButton.Location = new Point(82, 268);
             saveButton.Name = "saveButton";
             saveButton.Size = new Size(75, 23);
             saveButton.TabIndex = 21;
             saveButton.Text = "Save";
-            saveButton.UseVisualStyleBackColor = true;
+            saveButton.UseVisualStyleBackColor = false;
             saveButton.Click += saveButton_Click;
             // 
             // cancelButton
             // 
-            cancelButton.Location = new Point(212, 268);
+            cancelButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            cancelButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            cancelButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            cancelButton.FlatAppearance.BorderSize = 1;
+            cancelButton.FlatStyle = FlatStyle.Flat;
+            cancelButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            cancelButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
+            cancelButton.Location = new Point(430, 268); // Adjusted X for Right anchor
             cancelButton.Name = "cancelButton";
             cancelButton.Size = new Size(75, 23);
             cancelButton.TabIndex = 22;
             cancelButton.Text = "Cancel";
-            cancelButton.UseVisualStyleBackColor = true;
+            cancelButton.UseVisualStyleBackColor = false;
             cancelButton.Click += cancelButton_Click;
             // 
             // changePasswordLabel
             // 
             changePasswordLabel.AutoSize = true;
+            changePasswordLabel.Font = new System.Drawing.Font("Segoe UI", 10F);
+            changePasswordLabel.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             changePasswordLabel.Location = new Point(43, 88);
             changePasswordLabel.Name = "changePasswordLabel";
             changePasswordLabel.Size = new Size(119, 15);
@@ -146,8 +184,9 @@
             // 
             // PasswordChange
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             ClientSize = new Size(517, 321);
             Controls.Add(changePasswordLabel);
             Controls.Add(cancelButton);

--- a/grace/dialogs/SettingsForm.Designer.cs
+++ b/grace/dialogs/SettingsForm.Designer.cs
@@ -39,6 +39,10 @@
             // 
             // textBoxRowsPerPage
             // 
+            textBoxRowsPerPage.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            textBoxRowsPerPage.BorderStyle = BorderStyle.FixedSingle;
+            textBoxRowsPerPage.Font = new System.Drawing.Font("Segoe UI", 10F);
+            textBoxRowsPerPage.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             textBoxRowsPerPage.Location = new Point(121, 20);
             textBoxRowsPerPage.Margin = new Padding(2, 1, 2, 1);
             textBoxRowsPerPage.Name = "textBoxRowsPerPage";
@@ -48,29 +52,45 @@
             // 
             // SettingsCancelButton
             // 
+            SettingsCancelButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            SettingsCancelButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            SettingsCancelButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            SettingsCancelButton.FlatAppearance.BorderSize = 1;
+            SettingsCancelButton.FlatStyle = FlatStyle.Flat;
+            SettingsCancelButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            SettingsCancelButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             SettingsCancelButton.Location = new Point(110, 170);
             SettingsCancelButton.Margin = new Padding(2, 1, 2, 1);
             SettingsCancelButton.Name = "SettingsCancelButton";
             SettingsCancelButton.Size = new Size(83, 29);
             SettingsCancelButton.TabIndex = 1;
             SettingsCancelButton.Text = "Cancel";
-            SettingsCancelButton.UseVisualStyleBackColor = true;
+            SettingsCancelButton.UseVisualStyleBackColor = false;
             SettingsCancelButton.Click += CancelButton_Click;
             // 
             // SaveButton
             // 
+            SaveButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            SaveButton.BackColor = System.Drawing.ColorTranslator.FromHtml("#F5F5F5");
+            SaveButton.FlatAppearance.BorderColor = System.Drawing.ColorTranslator.FromHtml("#CFB53B");
+            SaveButton.FlatAppearance.BorderSize = 1;
+            SaveButton.FlatStyle = FlatStyle.Flat;
+            SaveButton.Font = new System.Drawing.Font("Segoe UI", 10F, FontStyle.Bold);
+            SaveButton.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             SaveButton.Location = new Point(13, 170);
             SaveButton.Margin = new Padding(2, 1, 2, 1);
             SaveButton.Name = "SaveButton";
             SaveButton.Size = new Size(82, 28);
             SaveButton.TabIndex = 2;
             SaveButton.Text = "Save";
-            SaveButton.UseVisualStyleBackColor = true;
+            SaveButton.UseVisualStyleBackColor = false;
             SaveButton.Click += SaveButton_Click;
             // 
             // label1
             // 
             label1.AutoSize = true;
+            label1.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label1.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label1.Location = new Point(6, 20);
             label1.Margin = new Padding(2, 0, 2, 0);
             label1.Name = "label1";
@@ -81,6 +101,8 @@
             // label2
             // 
             label2.AutoSize = true;
+            label2.Font = new System.Drawing.Font("Segoe UI", 10F);
+            label2.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             label2.Location = new Point(6, 52);
             label2.Margin = new Padding(2, 0, 2, 0);
             label2.Name = "label2";
@@ -90,6 +112,10 @@
             // 
             // rowHeighrTextBox
             // 
+            rowHeighrTextBox.BackColor = System.Drawing.ColorTranslator.FromHtml("#FFFAF0");
+            rowHeighrTextBox.BorderStyle = BorderStyle.FixedSingle;
+            rowHeighrTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            rowHeighrTextBox.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F");
             rowHeighrTextBox.Location = new Point(121, 52);
             rowHeighrTextBox.Margin = new Padding(2, 1, 2, 1);
             rowHeighrTextBox.Name = "rowHeighrTextBox";
@@ -99,8 +125,9 @@
             // 
             // SettingsForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
             ClientSize = new Size(431, 211);
             Controls.Add(rowHeighrTextBox);
             Controls.Add(label2);


### PR DESCRIPTION
This commit revamps the application's user interface to align with a wedding and catering business aesthetic.

Key changes include:

- Defined a new color palette (soft creams, muted gold, warm grays, rose gold accents) and font scheme (Georgia for headings, Segoe UI for body/controls).
- Applied the theme consistently across the main application window, all tabs, and associated controls.
- Styled DataGridViews with the new theme for improved readability and visual consistency.
- Re-themed all standard dialog windows (Add User, About, Settings, etc.) to match the main application.
- Updated custom-drawn controls (e.g., Admin tab's user ComboBox) to use the new theme colors and fonts.
- Set AutoScaleMode to Dpi for the main form and dialogs, and reviewed control anchoring for better behavior across different screen resolutions and DPI settings.

The overall goal was to create a more elegant, professional, and cohesive visual experience appropriate for the target business domain, while also improving UI consistency.