### PR TITLE
feat: Add release notes link to About dialog

### DIFF
--- a/grace/AboutBox.Designer.cs
+++ b/grace/AboutBox.Designer.cs
@@ -84,12 +84,27 @@
             button1.UseVisualStyleBackColor = false;
             button1.Click += Button1_Click;
             // 
+            // linkLabelReleases
+            //
+            this.linkLabelReleases = new System.Windows.Forms.LinkLabel();
+            this.linkLabelReleases.AutoSize = true;
+            this.linkLabelReleases.Font = new System.Drawing.Font("Segoe UI", 10F); // Match buildLabel font
+            this.linkLabelReleases.ForeColor = System.Drawing.ColorTranslator.FromHtml("#36454F"); // Match buildLabel color
+            this.linkLabelReleases.Location = new System.Drawing.Point(238, 171); // Position below buildLabel
+            this.linkLabelReleases.Name = "linkLabelReleases";
+            this.linkLabelReleases.Size = new System.Drawing.Size(150, 21); // Approximate size, AutoSize will adjust
+            this.linkLabelReleases.TabIndex = 4; // Next available tab index
+            this.linkLabelReleases.Text = "View Release Notes";
+            this.linkLabelReleases.TabStop = true; // Ensure it's a tab stop
+            this.linkLabelReleases.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelReleases_LinkClicked);
+            //
             // AboutBox
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             BackColor = System.Drawing.ColorTranslator.FromHtml("#FFF5EE");
-            ClientSize = new Size(520, 200);
+            ClientSize = new Size(520, 240);
+            Controls.Add(this.linkLabelReleases);
             Controls.Add(button1);
             Controls.Add(buildLabel);
             Controls.Add(authorLabel);
@@ -112,5 +127,6 @@
         private Label authorLabel;
         private Label buildLabel;
         private Button button1;
+        private System.Windows.Forms.LinkLabel linkLabelReleases;
     }
 }

--- a/grace/AboutBox.cs
+++ b/grace/AboutBox.cs
@@ -9,7 +9,10 @@
  * White Acre Software LLC.
  *
  */
- namespace grace
+using System.Diagnostics;
+using System.Windows.Forms;
+
+namespace grace
 {
     public partial class AboutBox : Form
     {
@@ -29,6 +32,25 @@
         private void Button1_Click(object sender, EventArgs e)
         {
             this.Close();
+        }
+
+        private void linkLabelReleases_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            try
+            {
+                // Navigate to the URL.
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "https://github.com/whiteacrellc/grace/releases",
+                    UseShellExecute = true // Important for opening URLs in the default browser
+                });
+            }
+            catch (System.Exception ex)
+            {
+                // Optionally, handle any exceptions that might occur when trying to open the link
+                // For example, log the error or show a message to the user
+                // System.Windows.Forms.MessageBox.Show($"Unable to open link: {ex.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a clickable "View Release Notes" link to the About dialog. This link directs you to the project's GitHub releases page: https://github.com/whiteacrellc/grace/releases

The implementation involved:
- Adding a LinkLabel control to AboutBox.Designer.cs.
- Creating an event handler in AboutBox.cs to open the URL.
- Adjusting form layout to accommodate the new link.