### PR TITLE
Fix CollectionTab not refreshing when Grace data changes

### DIFF
--- a/grace/Globals.cs
+++ b/grace/Globals.cs
@@ -21,10 +21,12 @@ namespace grace
 
         public string CurrentUser { get; set; }
         public bool CollectionDirty { get; set; }
+        public bool GraceDataDirty { get; set; }
 
         private Globals()
         {
             CollectionDirty = false;
+            GraceDataDirty = false;
         }
         public static Globals GetInstance()
         {

--- a/grace/dialogs/EditRowForm.cs
+++ b/grace/dialogs/EditRowForm.cs
@@ -412,6 +412,7 @@ namespace grace
             if (!ret && updateGraceRow)
             {
                 DataBase.UpdateGraceRow(graceId);
+                Globals.GetInstance().GraceDataDirty = true;
             }
 
             return ret;
@@ -589,13 +590,15 @@ namespace grace
                 DataBase.UpdateArrangementWithNewCollection(cName);
             }
 
-            // Now add the grace row. 
+            // Now add the grace row.
             DataBase.CreateGraceRow(graceId);
 
             if (updateBrandDropdown)
             {
                 brandComboBox.Items.Add(brand);
             }
+
+            Globals.GetInstance().GraceDataDirty = true;
 
             return ret;
         }

--- a/grace/tabs/CollectionTab.cs
+++ b/grace/tabs/CollectionTab.cs
@@ -46,10 +46,14 @@ namespace grace.tabs
                 .Distinct()
                 .OrderBy(name => name)];
 
+            // Clear existing items before adding to prevent duplicates
+            colReportComboBox.Items.Clear();
             foreach (string d in distinctCollectionNames)
             {
                 colReportComboBox.Items.Add(d);
             }
+            // Create a new Report to get fresh data (avoids duplicate rows)
+            this.report = new Report();
             this.dataTable = report.CreateCollectionTable();
             colReportComboBox.SelectedIndex = -1;
         }
@@ -68,6 +72,11 @@ namespace grace.tabs
             {
                 BuildCollectionInfo();
                 Globals.GetInstance().CollectionDirty = false;
+            }
+            else if (Globals.GetInstance().GraceDataDirty)
+            {
+                RefreshDataFromDatabase();
+                Globals.GetInstance().GraceDataDirty = false;
             }
             colReportComboBox.SelectedIndex = -1;
             RefreshData();
@@ -144,6 +153,13 @@ namespace grace.tabs
         internal void RefreshData()
         {
             collGridView.DataSource = dataTable;
+        }
+
+        private void RefreshDataFromDatabase()
+        {
+            // Create a new Report to get fresh data from the database
+            this.report = new Report();
+            this.dataTable = report.CreateCollectionTable();
         }
         internal void UpdateDataGridView()
         {


### PR DESCRIPTION
Added GraceDataDirty flag to Globals that gets set when Grace data (brand, note, availability, etc.) is modified in EditRowForm. The CollectionTab now checks this flag when entered and refreshes its data from the database.

Also fixed a bug where calling BuildCollectionInfo() multiple times would cause duplicate items in the combo box and duplicate rows in the data table.

Changes:
- Added GraceDataDirty property to Globals class
- Set GraceDataDirty in EditRowForm.UpdateRow() and AddRow()
- Added RefreshDataFromDatabase() method to CollectionTab
- CollectionTab now checks GraceDataDirty flag on Enter event
- Clear combo box items before adding in BuildCollectionInfo()
- Create new Report instance to avoid duplicate rows